### PR TITLE
Refactor Error Handling in Client

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -217,8 +217,17 @@ class Client:
                 a tuple containing job_id, url, and job_type
         """
         print('performing job')
-        response = self.server_validator.get_request(
-            '/get_job', params={'client_id': self.client_id})
+
+        try:
+            work_server_hostname = os.getenv('WORK_SERVER_HOSTNAME')
+            work_server_port = os.getenv('WORK_SERVER_PORT')
+            url = f'http://{work_server_hostname}:{work_server_port}'
+
+            response = requests.get(f'{url}/get_job', params={'client_id': self.client_id})
+            response.raise_for_status()
+        except (HTTPError, RequestConnectionError):
+            print('There was an error handling this response.')
+
         job = loads(response.text)
         if 'error' in job:
             raise NoJobsAvailableException()

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -86,7 +86,7 @@ def test_client_gets_job(mock_requests):
     client = Client(server_validator, Validator())
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1', 'url': 1, 'job_type': 'attachments',
                   'reg_id': '1', 'agency': 'foo'},
             status_code=200
@@ -104,7 +104,7 @@ def test_client_throws_exception_when_no_jobs(mock_requests):
     client = Client(server_validator, Validator())
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'error': 'No jobs available'},
             status_code=403
         )
@@ -147,7 +147,7 @@ def test_client_performs_job(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'documents',
@@ -180,7 +180,7 @@ def test_client_returns_403_error_to_server(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'documents',
@@ -218,7 +218,7 @@ def test_client_returns_400_error_to_server(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'documents',
@@ -254,7 +254,7 @@ def test_client_returns_500_error_to_server(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'documents',
@@ -292,7 +292,7 @@ def test_client_sends_attachment_results(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'attachments',
@@ -335,7 +335,7 @@ def test_client_handles_empty_json_from_regulations(mock_requests):
 
     with mock_requests:
         mock_requests.get(
-            'http://test.com/get_job',
+            'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
                   'url': 'http://url.com',
                   'job_type': 'attachments',


### PR DESCRIPTION
We need to re-work how the client handles non-happy-path cases.  Right now, the `Validator` uses [`raise_for_status()`](https://requests.readthedocs.io/en/latest/user/quickstart/?highlight=raise_for_status#response-status-codes) inside a `try`/`accept` block.  This is too low-level - when we catch the exception we don't know what action should be taken.

We need to let exceptions *propagate* up to the place where we know the appropriate behavior.

The "Happy Path" of the client is:

```
get a job from the work server
download the data from regulations.gov
return the results to the work server
```

The challenge is that errors can occur:

* The work server is down
* There are no jobs available
* regulations.gov is down
* The API key has no calls available
* etc.

These errors fall into two categories:

* Errors from the work server are fatal - we can't recover and keep going.
* Errors from regulations.gov need to be reported back to the work server (this currently isn't implemented)

The best way to handle errors is with exceptions.  This requires us to design where exceptions will be generated and where they will be handled.

### Error Handling with One Job

The following expands the happy path to include errors related to regulations.gov:


```
get a job from the work server
if basic job
  try:
    download from regulations.gov
    return result to work server
  except RegulationsError
    report error to work server (currently not implemented)
else attachments job
  try:
    download attachments
    return result(s) to work server
  except RegulationsError
    report error to work server (currently not implemented)
```


### Main

Errors related to the work server should propagate to the main level:

```
try:
  One Job
except WorkServerError
  print error message
sleep 3.6s
```

* NOTE: Any print statement will be logged by Docker (with a timestamp).



