### PR TITLE
Added logging for client & work server

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -148,8 +148,7 @@ class Client:
         :raises: NoJobsAvailableException
             If no job is available from the work server
         """
-        print('performing job')
-
+        print('Staring New Job')
         response = requests.get(f'{self.url}/get_job',
                                 params={'client_id': self.client_id},
                                 timeout=10)
@@ -184,6 +183,7 @@ class Client:
             'reg_id': job['reg_id'],
             'agency': job['agency']
         }
+        print('Sending Job to Work Server')
         # If the job is not an attachment job we need to add an output path
         if ('errors' not in job_result) and (job['job_type'] != 'attachments'):
             data['directory'] = get_output_path(job_result)

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -283,6 +283,7 @@ def put_attachment_results(workserver, data):
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
     if data.get('results') is not None:
+        print('Attachment Job Being Saved')
         print('agency', data['agency'])
         print('reg_id', data['reg_id'])
         workserver.attachment_saver.save(


### PR DESCRIPTION
When looking at the logs, using `docker-compose -t`, for a client or the work server there was no clear indication of what action was being performed. I added a few statements that would make following and understanding the logs easier

@pereze03 can you please review and check to see if there are any other log messages that could be added