### PR TITLE
Fix typo in client logging

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -149,7 +149,7 @@ class Client:
         :raises: NoJobsAvailableException
             If no job is available from the work server
         """
-        print('Staring New Job')
+        print('Starting New Job')
         response = requests.get(f'{self.url}/get_job',
                                 params={'client_id': self.client_id},
                                 timeout=10)


### PR DESCRIPTION
* Small change but changes 'Staring New Job'  to 'Starting New Job'