### PR TITLE
Make work-server output file path when saving job

### DIFF
--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -255,7 +255,8 @@ def put_results(workserver, data):
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
     write_results(results[0], data['directory'], data['results'])
-    print(f"Writing job to {data['directory']}")
+    filename = data['directory'].split("/")[-1]
+    print(f"Wrote job name: {filename}, job_id: {job_id}, to {data['directory']}")
     workserver.data.add(data['results'])
     print('Job success for client:'+client_id+', '+'job: ', job_id)
     return (True,)

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -256,7 +256,7 @@ def put_results(workserver, data):
     workserver.redis.hdel('jobs_in_progress', job_id)
     write_results(results[0], data['directory'], data['results'])
     print(f"Wrote job {data['directory'].split('/')[-1]},"
-          f"job_id: {job_id}, to {data['directory']}")
+          f" job_id: {job_id}, to {data['directory']}")
     workserver.data.add(data['results'])
     print(f'Job success for client:{client_id}, job: {job_id}')
     return (True,)

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -255,10 +255,10 @@ def put_results(workserver, data):
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
     write_results(results[0], data['directory'], data['results'])
-    filename = data['directory'].split("/")[-1]
-    print(f"Wrote job name: {filename}, job_id: {job_id}, to {data['directory']}")
+    print(f"Wrote job {data['directory'].split('/')[-1]},"
+          f"job_id: {job_id}, to {data['directory']}")
     workserver.data.add(data['results'])
-    print('Job success for client:'+client_id+', '+'job: ', job_id)
+    print(f'Job success for client:{client_id}, job: {job_id}')
     return (True,)
 
 

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -255,6 +255,7 @@ def put_results(workserver, data):
     job_id = data['job_id']
     workserver.redis.hdel('jobs_in_progress', job_id)
     write_results(results[0], data['directory'], data['results'])
+    print(f"Writing job to {data['directory']}")
     workserver.data.add(data['results'])
     print('Job success for client:'+client_id+', '+'job: ', job_id)
     return (True,)


### PR DESCRIPTION
The client already logs the file path when sending a job back to the work server. I added a log line to the work-server so that it also outputs the file path of the saved job. 