### PR TITLE
Remove Client28 due to API-Key Repetiton

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,11 +260,3 @@ services:
       - work_server
     env_file: env_files/client27.env
     restart: always
-  client28:
-    build:
-      context: .
-      dockerfile: mirrulations-client/Dockerfile
-    depends_on:
-      - work_server
-    env_file: env_files/client27.env
-    restart: always

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,7 +60,7 @@ Because a local instance of the system should only run for a short period of tim
 To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/). 
 
 * Create a folder named `env_files`.  
-* In `env_files`, create `client1.env`, `client2.env`, ... up to `client28.env`.  Each file should have the following format:
+* In `env_files`, create `client1.env`, `client2.env`, ... up to `client27.env`.  Each file should have the following format:
 
   ```
   WORK_SERVER_HOSTNAME=work_server

--- a/mirrulations-dashboard/src/mirrdash/static/index.js
+++ b/mirrulations-dashboard/src/mirrdash/static/index.js
@@ -72,7 +72,6 @@ const updateDashboardData = () => {
             client25,
             client26,
             client27,
-            client28,
             jobs_total,
             nginx,
             num_attachments_done,
@@ -119,7 +118,6 @@ const updateDashboardData = () => {
         updateStatus('client25-status', client25)
         updateStatus('client26-status', client26)
         updateStatus('client27-status', client27)
-        updateStatus("client28-status", client28)
         updateStatus('nginx-status', nginx)
         updateStatus('mongo-status', mongo)
         updateStatus('redis-status', redis);

--- a/mirrulations-dashboard/src/mirrdash/templates/index.html
+++ b/mirrulations-dashboard/src/mirrdash/templates/index.html
@@ -377,14 +377,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="card header-card">
-                        <div class="info-container">
-                            <div class="info-container-data">
-                                <h3>Client 28</h3>
-                                <span id="client28-status">0</span>
-                            </div>
-                        </div>
-                    </div>
                 </div>
 
             </div>


### PR DESCRIPTION
* Kyle and Evan found that I had used the same key for two clients in deployment. To correct this:
* Client 28 was removed from the docker compose file and the dashboard.
* The documentation now has developers make 27 clients instead of 28.
* Modification to the .env files in the box will need to be done before this change is deployed into production. 
