### PR TITLE
Remove work server assigning client ID

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -7,17 +7,16 @@ and send results back to the server by making the calls to [regulations.gov]
 (https://www.regulations.gov/) for data downloads. 
 
 ## Description 
-Multiple clients will be able to connect to the work server at once. A client 
-will also try to get a `client_id` if it doesn't have one already. The goal is 
+Multiple clients will be able to connect to the work server at once. The goal is 
 that the client will request and complete work in order to download data from 
 [regulations.gov](https://www.regulations.gov/) to disk. 
 
 
 ### `/get_job`
-Makes a request to get a specific with an endpoint consisting of the Job's URL and the clients ID. Makes sure there is an available job and saves the Job's URL, ID and Type , i.e Attachment, Comment, Doc..
+Makes a request to get a specific with an endpoint consisting of the Job's URL and the clients ID. Makes sure there is an available job and saves the Job's URL, ID and Type, i.e Attachment, Comment, Doc..
 
 ### `/execute_task`
-Will be used to call get_job, printing updates along the way. Will eventually have an if statement to separate the calls for different job types.Is able to call perform_job, using the Job's url+endpoint, and then once the results have been find, the job results are sent back to the server.  
+Will be used to call get_job, printing updates along the way. Will eventually have an if statement to separate the calls for different job types. Is able to call perform_job, using the Job's url+endpoint, and then once the results have been find, the job results are sent back to the server.  
 
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,7 @@ To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/).
   WORK_SERVER_HOSTNAME=work_server
   WORK_SERVER_PORT=8080
   API_KEY=YOUR_KEY
+  ID=CLIENT_NUMBER
   ```
 
 * In `env_files`, create `work_gen.env` containing: 

--- a/docs/env_files.md
+++ b/docs/env_files.md
@@ -5,6 +5,7 @@ For clients to make calls to the Regulations.gov API, they each need a unique AP
 	WORK_SERVER_HOSTNAME=___________
 	WORK_SERVER_PORT=____
 	API_KEY=_______________
+	ID=____
 
 ## How to Add New Clients
 To add a new client, 

--- a/docs/production.md
+++ b/docs/production.md
@@ -10,7 +10,7 @@ The system is Dockerized into a number of components:
 * `work_generator` - Crawl through the regulations.gov results to find missing data
 * `work_server` - Server jobs to clients and save results
 * `dashboard` - Web-based user interface to observe progress 
-* `client1` through `client15` - Clients that download data from regulations.gov
+* `client1` through `client27` - Clients that download data from regulations.gov
 
 ## Docker Compose commands
 

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -100,7 +100,8 @@ def is_environment_variables_present():
     """
     return (os.getenv('WORK_SERVER_HOSTNAME') is not None
             and os.getenv('WORK_SERVER_PORT') is not None
-            and os.getenv('API_KEY') is not None)
+            and os.getenv('API_KEY') is not None
+            and os.getenv('ID') is not None)
 
 
 class Client:
@@ -125,22 +126,11 @@ class Client:
 
     def __init__(self):
         self.api_key = os.getenv('API_KEY')
-        self.client_id = -1
+        self.client_id = os.getenv('ID')
 
         hostname = os.getenv('WORK_SERVER_HOSTNAME')
         port = os.getenv('WORK_SERVER_PORT')
         self.url = f'http://{hostname}:{port}'
-
-    def get_id(self):
-        """
-        Retrieves an id for the Client from the workserver.
-        That value is saved to client_id then written to
-        a client.cfg file.
-        """
-        response = requests.get(f'{self.url}/get_client_id', timeout=10)
-        self.client_id = int(response.json()['client_id'])
-        with open('client.cfg', 'w', encoding='utf8') as file:
-            file.write(str(self.client_id))
 
     def get_job(self):
         """
@@ -303,9 +293,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     client = Client()
-    client.get_id()
 
-    print('Your ID is: ', client.client_id)
     while True:
         try:
             client.job_operation()

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -16,6 +16,7 @@ def mock_env():
     os.environ['WORK_SERVER_HOSTNAME'] = 'work_server'
     os.environ['WORK_SERVER_PORT'] = '8080'
     os.environ['API_KEY'] = 'TESTING_KEY'
+    os.environ['ID'] = '-1'
 
 
 @fixture(name='mock_requests')
@@ -49,6 +50,12 @@ def test_check_no_api_key():
     assert is_environment_variables_present() is False
 
 
+def test_client_has_no_id():
+    # Need to delete id env variable set by mock_env fixture
+    del os.environ['ID']
+    assert is_environment_variables_present() is False
+
+
 def test_client_gets_job(mock_requests):
     client = Client()
     with mock_requests:
@@ -77,18 +84,6 @@ def test_client_throws_exception_when_no_jobs(mock_requests):
 
         with raises(NoJobsAvailableException):
             client.get_job()
-
-
-def test_client_gets_id_from_server(mock_requests):
-    with mock_requests:
-        mock_requests.get(
-            'http://work_server:8080/get_client_id',
-            json={'client_id': 1},
-            status_code=200
-        )
-        client = Client()
-        client.get_id()
-        assert client.client_id == 1
 
 
 def test_api_call_has_api_key(mock_requests):
@@ -171,16 +166,6 @@ def test_client_returns_403_error_to_server(mock_requests):
         client.job_operation()
         response = mock_requests.request_history[-1]
         assert '403' in response.json()
-
-
-def test_get_id_timesout(mock_requests):
-    with mock_requests:
-        mock_requests.get(
-            'http://work_server:8080/get_client_id',
-            exc=Timeout)
-
-        with pytest.raises(Timeout):
-            Client().get_id()
 
 
 def test_get_job_timesout(mock_requests):


### PR DESCRIPTION
Work server no longer assigns client IDs. Client uses ID stored in its respective .env file (ID= ). Removed some of the outdated tests and created a test for the new functionality.