### PR TITLE
Remove work server functions

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,7 @@ To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/).
   WORK_SERVER_HOSTNAME=work_server
   WORK_SERVER_PORT=8080
   API_KEY=YOUR_KEY
+  ID=CLIENT_NUMBER
   ```
 
 * In `env_files`, create `work_gen.env` containing: 

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -100,7 +100,8 @@ def is_environment_variables_present():
     """
     return (os.getenv('WORK_SERVER_HOSTNAME') is not None
             and os.getenv('WORK_SERVER_PORT') is not None
-            and os.getenv('API_KEY') is not None)
+            and os.getenv('API_KEY') is not None
+            and os.getenv('ID') is not None)
 
 
 class Client:
@@ -125,22 +126,11 @@ class Client:
 
     def __init__(self):
         self.api_key = os.getenv('API_KEY')
-        self.client_id = -1
+        self.client_id = os.getenv('ID')
 
         hostname = os.getenv('WORK_SERVER_HOSTNAME')
         port = os.getenv('WORK_SERVER_PORT')
         self.url = f'http://{hostname}:{port}'
-
-    def get_id(self):
-        """
-        Retrieves an id for the Client from the workserver.
-        That value is saved to client_id then written to
-        a client.cfg file.
-        """
-        response = requests.get(f'{self.url}/get_client_id', timeout=10)
-        self.client_id = int(response.json()['client_id'])
-        with open('client.cfg', 'w', encoding='utf8') as file:
-            file.write(str(self.client_id))
 
     def get_job(self):
         """
@@ -303,9 +293,7 @@ if __name__ == '__main__':
         sys.exit(1)
 
     client = Client()
-    client.get_id()
 
-    print('Your ID is: ', client.client_id)
     while True:
         try:
             client.job_operation()

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -16,6 +16,7 @@ def mock_env():
     os.environ['WORK_SERVER_HOSTNAME'] = 'work_server'
     os.environ['WORK_SERVER_PORT'] = '8080'
     os.environ['API_KEY'] = 'TESTING_KEY'
+    os.environ['ID'] = '-1'
 
 
 @fixture(name='mock_requests')
@@ -49,6 +50,12 @@ def test_check_no_api_key():
     assert is_environment_variables_present() is False
 
 
+def test_client_has_no_id():
+    # Need to delete id env variable set by mock_env fixture
+    del os.environ['ID']
+    assert is_environment_variables_present() is False
+
+
 def test_client_gets_job(mock_requests):
     client = Client()
     with mock_requests:
@@ -77,18 +84,6 @@ def test_client_throws_exception_when_no_jobs(mock_requests):
 
         with raises(NoJobsAvailableException):
             client.get_job()
-
-
-def test_client_gets_id_from_server(mock_requests):
-    with mock_requests:
-        mock_requests.get(
-            'http://work_server:8080/get_client_id',
-            json={'client_id': 1},
-            status_code=200
-        )
-        client = Client()
-        client.get_id()
-        assert client.client_id == 1
 
 
 def test_api_call_has_api_key(mock_requests):
@@ -171,16 +166,6 @@ def test_client_returns_403_error_to_server(mock_requests):
         client.job_operation()
         response = mock_requests.request_history[-1]
         assert '403' in response.json()
-
-
-def test_get_id_timesout(mock_requests):
-    with mock_requests:
-        mock_requests.get(
-            'http://work_server:8080/get_client_id',
-            exc=Timeout)
-
-        with pytest.raises(Timeout):
-            Client().get_id()
 
 
 def test_get_job_timesout(mock_requests):

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -76,29 +76,6 @@ def check_for_database(workserver):
     workserver.redis.ping()
 
 
-def check_valid_request_client_id(workserver, client_id):
-    """
-    Checks if the client id is valid
-    calls the check_client_id_valid function
-
-    Parameters
-    ----------
-    workserver : WorkServer
-        the work server class
-    client_id : int
-        the client id validating
-
-    Returns
-    -------
-    True or False : bool
-        True if the client id is valid, False if not
-        False will also return an error message
-    """
-    if not check_client_id_is_valid(workserver, client_id):
-        return False, jsonify({'error': 'Invalid client ID'}), 401
-    return (True,)
-
-
 def decrement_count(workserver, job_type):
     """
     for each job type, when that type of job is taken, remove one from
@@ -143,9 +120,6 @@ def get_job(workserver):
     """
     check_for_database(workserver)
     client_id = request.args.get('client_id')
-    success, *values = check_valid_request_client_id(workserver, client_id)
-    if not success:
-        return False, values[0], values[1]
     if workserver.redis.llen('jobs_waiting_queue') == 0:
         return False, jsonify({'error': 'No jobs available'}), 403
     job = json.loads(workserver.redis.rpop('jobs_waiting_queue'))
@@ -232,9 +206,6 @@ def write_results(directory, path, data):
 def check_received_result(workserver):
     check_for_database(workserver)
     client_id = request.args.get('client_id')
-    success, *values = check_valid_request_client_id(workserver, client_id)
-    if not success:
-        return False, values[0], values[1]
     print('Work_server received job for client: ', client_id)
     return True, client_id
 
@@ -297,51 +268,6 @@ def put_attachment_results(workserver, data):
             data, f"/data/{data['agency']}/{data['reg_id']}")
     workserver.data.add_attachment(data)
     return (True,)
-
-
-def get_client_id(workserver):
-    """
-    called when a client is started and needs a client id.
-    Increments the total number of clients and gives
-    the number to the client.
-
-
-    Parameters
-    ----------
-    workserver : WorkServer
-        the work server class
-
-    Returns
-    -------
-    client_id : int
-        the client id generated for the client
-    """
-    check_for_database(workserver)
-    workserver.redis.incr('total_num_client_ids')
-    return True, int(workserver.redis.get('total_num_client_ids'))
-
-
-def check_client_id_is_valid(workserver, client_id):
-    """
-    checks that the client id is lower than the
-    total number of clients and higher than 0
-
-    Parameters
-    ----------
-    workserver : WorkServer
-        the work server class
-    client_id : int
-        the client id
-
-    Returns
-    -------
-    bool if the client id is valid
-    """
-    check_for_database(workserver)
-    num_ids = workserver.redis.get('total_num_client_ids')
-    total_ids = 0 if num_ids is None else int(num_ids)
-    client_id = int(client_id)
-    return 0 < client_id <= total_ids
 
 
 def create_server(database):
@@ -414,27 +340,6 @@ def create_server(database):
         if not success:
             return tuple(values)
         return jsonify(validator[0]), validator[1]
-
-    @workserver.app.route('/get_client_id', methods=['GET'])
-    def _get_client_id():
-        """
-        The endpoint a client calls when requesting a client ID
-
-        Returns
-        -------
-        response : json
-            if success:
-                {'client_id': client_id}, status code
-            if error:
-                {'error': 'Cannot connect to the database'}), 500
-        """
-        try:
-            success, *values = get_client_id(workserver)
-            if not success:
-                return tuple(values)
-            return jsonify({'client_id': values[0]}), 200
-        except redis.exceptions.ConnectionError:
-            return jsonify({'error': 'Cannot connect to the database'}), 500
 
     return workserver
 


### PR DESCRIPTION
We removed functions that made client IDs using the redis database. The logs still output the correct ID numbers and not the redis numbers even with these functions removed. We still have to update the tests to accommodate for these changes but this should be ready to be merged.