### PR TITLE
Attachment Refactor for Client

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -86,6 +86,10 @@ def get_output_path(results):
     output_path += results["data"]["id"] + "/"
     output_path += results["data"]["id"] + ".json"
     print(f'Job output path: {output_path}')
+    print(output_path)
+    print(output_path)
+    print(output_path)
+
     return output_path
 
 
@@ -192,6 +196,10 @@ class Client:
             'reg_id': job['reg_id'],
             'agency': job['agency']
         }
+        print(job_result)
+        print(job_result)
+        print(job_result)
+
         print(f'Sending Job {job["job_id"]} to Work Server')
         # If the job is not an attachment job we need to add an output path
         if ('errors' not in job_result) and (job['job_type'] != 'attachments'):
@@ -246,25 +254,24 @@ class Client:
         -------
         a dict of encoded files
         """
-        non_api_url = url
         url = url + f'?api_key={self.api_key}'
-        response_from_related = requests.get(url, timeout=10).json()
+        response_json = requests.get(url, timeout=10).json()
 
-        if not self.is_attachment_json_valid(
-                response_from_related, non_api_url):
+        if not self.does_attachment_exists(response_json):
+            print(f"No attachments to download from {url}")
             return {}
 
         # Get Attachments
         print(f"SUCCESS: Performing attachment job {job_id}")
         file_info = \
-            response_from_related["data"][0]["attributes"]["fileFormats"]
+            response_json["data"][0]["attributes"]["fileFormats"]
         file_urls, file_types = get_urls_and_formats(file_info)
         return self.download_attachments(file_urls, file_types, job_id)
 
-    def is_attachment_json_valid(self, attachment_json, url):
+    def does_attachment_exists(self, attachment_json):
         """
         Validates whether a json for an attachment is valid to continue
-        download process
+        download process. Invalid JSON means no attachment(s) available
 
         RETURNS
         -------
@@ -274,9 +281,6 @@ class Client:
         if not attachment_json['data'] \
             or attachment_json['data'][0]['attributes']['fileFormats'] \
                 == "null":
-            print(
-                f"FAILURE: {'Empty' if not attachment_json['data'] else 'No'} \
-                    attachment list provided from {url}")
             return False
         return True
 

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -249,6 +249,7 @@ class Client:
         file_info = \
             response_json["data"][0]["attributes"]["fileFormats"]
         file_urls, file_types = get_urls_and_formats(file_info)
+
         return self.download_attachments(file_urls, file_types, job_id)
 
     def does_attachment_exists(self, attachment_json):

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -249,7 +249,6 @@ class Client:
         file_info = \
             response_json["data"][0]["attributes"]["fileFormats"]
         file_urls, file_types = get_urls_and_formats(file_info)
-
         return self.download_attachments(file_urls, file_types, job_id)
 
     def does_attachment_exists(self, attachment_json):

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -86,9 +86,6 @@ def get_output_path(results):
     output_path += results["data"]["id"] + "/"
     output_path += results["data"]["id"] + ".json"
     print(f'Job output path: {output_path}')
-    print(output_path)
-    print(output_path)
-    print(output_path)
 
     return output_path
 
@@ -196,10 +193,6 @@ class Client:
             'reg_id': job['reg_id'],
             'agency': job['agency']
         }
-        print(job_result)
-        print(job_result)
-        print(job_result)
-
         print(f'Sending Job {job["job_id"]} to Work Server')
         # If the job is not an attachment job we need to add an output path
         if ('errors' not in job_result) and (job['job_type'] != 'attachments'):
@@ -277,11 +270,16 @@ class Client:
         -------
         True or False depending if there is an attachment available to download
         """
-        # Handles IndexError and NoneType
-        if not attachment_json['data'] \
-            or attachment_json['data'][0]['attributes']['fileFormats'] \
-                == "null":
+        # handle keyError
+        if "data" not in attachment_json:
             return False
+        # Handles IndexError
+        if attachment_json.get("data") == []:
+            return False
+        # Handles NoneType
+        if len(attachment_json['data']) >= 1:
+            if not attachment_json['data'][0]['attributes']['fileFormats']:
+                return False
         return True
 
     def download_attachments(self, urls, file_types, job_id):

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -260,15 +260,18 @@ class Client:
         -------
         True or False depending if there is an attachment available to download
         """
-        # handle keyError
-        if "data" not in attachment_json:
+        # handle KeyError
+        if attachment_json.get('data') in (None, []):
             return False
+        data = attachment_json.get('data')
         # Handles IndexError
-        if attachment_json.get("data") == []:
-            return False
-        # Handles NoneType
-        if len(attachment_json['data']) >= 1:
-            if not attachment_json['data'][0]['attributes']['fileFormats']:
+        if len(data) >= 1:
+            # Check if attributes and fileFormats exists
+            if ("attributes" not in data[0]) or \
+                    ("fileFormats" not in data[0].get('attributes')):
+                return False
+            # handles NoneType in the fileFormats when null
+            if not data[0]['attributes']['fileFormats']:
                 return False
         return True
 

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -412,7 +412,7 @@ def test_handles_nonetype_error(mock_requests):
             json={
                 "data": [{
                     "attributes": {
-                        "fileFormats": "null",
+                        "fileFormats": None,
                     }
                 }]
             },

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -401,21 +401,21 @@ def test_handles_nonetype_error(mock_requests):
         mock_requests.get(
             'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
-                  'url': 'http://url.com',
+                  'url': 'http://regulations.gov/job',
                   'job_type': 'attachments',
                   'reg_id': '1',
                   'agency': 'foo'},
             status_code=200
         )
         mock_requests.get(
-            'http://url.com?api_key=1234',
+            'http://regulations.gov/job?api_key=1234',
             json={
                 "data": [{
                     "attributes": {
                         "fileFormats": "null",
-                        }
-                    }]
-                },
+                    }
+                }]
+            },
             status_code=200
         )
 
@@ -441,14 +441,14 @@ def test_handles_index_error(mock_requests):
         mock_requests.get(
             'http://work_server:8080/get_job?client_id=-1',
             json={'job_id': '1',
-                  'url': 'http://url.com',
+                  'url': 'http://regulations.gov/job',
                   'job_type': 'attachments',
                   'reg_id': '1',
                   'agency': 'foo'},
             status_code=200
         )
         mock_requests.get(
-            'http://url.com?api_key=1234',
+            'http://regulations.gov/job?api_key=1234',
             json={"data": []},
             status_code=200
         )


### PR DESCRIPTION
- Refactored perform_attachment_job() in Client.py to not use a try-except block. Refactor checks if the JSON for an attachment is valid, essentially checking if there are any attachments to download. If there aren't attachments, no further steps need to be taken. 

- Also added some mock tests that mimic the handling of TypeError (NoneType) and IndexError