### PR TITLE
Add discussion of PYTHONUNBUFFERED=TRUE in .env files

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,12 +66,16 @@ To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/).
   WORK_SERVER_HOSTNAME=work_server
   WORK_SERVER_PORT=8080
   API_KEY=YOUR_KEY
+  PYTHONUNBUFFERED=TRUE
   ```
+  
+  The `PYTHONUNBUFFERED=TRUE` line tells Python to execute `print` statements without buffering (so that we can view logs in realtime).
 
 * In `env_files`, create `work_gen.env` containing: 
   
   ```
   API_KEY=YOUR_KEY
+  PYTHONUNBUFFERED=TRUE
   ```
   
 * In `env_files`, create `dashboard.env` containing: 
@@ -79,6 +83,7 @@ To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/).
   ```
   MONGO_HOSTNAME=mongo
   REDIS_HOSTNAME=redis
+  PYTHONUNBUFFERED=TRUE
   ```
 
 * All data is stored in subfolders of `~/data`.  You must create this folder before launching:

--- a/docs/env_files.md
+++ b/docs/env_files.md
@@ -5,6 +5,9 @@ For clients to make calls to the Regulations.gov API, they each need a unique AP
 	WORK_SERVER_HOSTNAME=___________
 	WORK_SERVER_PORT=____
 	API_KEY=_______________
+    PYTHONUNBUFFERED=TRUE
+
+The `PYTHONUNBUFFERED=TRUE` tells Python to output immediately so that we can view logs in realtime.
 
 ## How to Add New Clients
 To add a new client, 


### PR DESCRIPTION
When looking at the docker-compose logs, we were seeing bursts of log activity.  This was caused because Python was buffering output - from Docker's perspective, there were no logs, and then a large number of lines would arrive in a fraction of a second.

By setting the PYTHONUNBUFFERED environment variable, Python will stop using buffered output, and instead generate output immediately.  This causes the lines to arrive at Docker as soon as they are generated, which makes our logs accurately reflect what is happening in the containers.