### PR TITLE
Make setup script for development

### DIFF
--- a/dev_setup.py
+++ b/dev_setup.py
@@ -4,7 +4,7 @@ import shutil
 
 def create_env_folder():
     parent_dir = os.path.realpath(os.path.expanduser("."))
-    dir_name = "env_files/" # Change name back to original
+    dir_name = "env_files/"
     env_path = os.path.join(parent_dir, dir_name)
     if(os.path.exists(env_path)):
         shutil.rmtree(env_path)

--- a/dev_setup.py
+++ b/dev_setup.py
@@ -1,0 +1,65 @@
+import os
+import re
+import shutil
+
+def create_env_folder():
+    parent_dir = os.path.realpath(os.path.expanduser("."))
+    dir_name = "env_files/" # Change name back to original
+    env_path = os.path.join(parent_dir, dir_name)
+    if(os.path.exists(env_path)):
+        shutil.rmtree(env_path)
+    os.mkdir(env_path)
+
+    return env_path
+
+def get_total_client_number():
+    matches = []
+    with open('docker-compose.yml') as file:
+        for line in file:
+            match = re.findall("(client\d.env|client\d\d.env)", line)
+            if len(match) == 1:
+                matches += match
+    return matches
+
+def write_files(api_key, env_path, total_clients):
+    # Write client files
+    for i in range(1, len(total_clients) + 1):
+          with open("{}client{}.env".format(env_path, i), 'w') as file:
+            file.write("WORK_SERVER_HOSTNAME=work_server" + "\n")
+            file.write("WORK_SERVER_PORT=8080" + "\n")
+            file.write("API_KEY={}".format(api_key) + "\n")
+            file.write("ID={}".format(i) + "\n")
+            file.write("PYTHONUNBUFFERED=TRUE")
+
+    # Write work generator file
+    with open("{}work_gen.env".format(env_path), 'w') as file:
+        file.write("API_KEY={}".format(api_key) + "\n")
+        file.write("PYTHONUNBUFFERED=TRUE")
+
+    # Write dashboard file
+    with open("{}dashboard.env".format(env_path), 'w') as file:
+        file.write("MONGO_HOSTNAME=mongo" + "\n")
+        file.write("REDIS_HOSTNAME=redis" + "\n")
+        file.write("PYTHONUNBUFFERED=TRUE")
+    
+    # Create data folder 
+    parent_dir = os.path.realpath(os.path.expanduser("~"))
+    dir_name = "data/"
+    data_path = os.path.join(parent_dir, dir_name)
+
+    if(not os.path.exists(data_path)):
+        os.mkdir(data_path)
+
+
+if __name__ == "__main__":
+
+    # Get user input for API key
+    api_key = input("Enter your API key from regulations.gov: ")
+
+    env_path = create_env_folder() 
+    total_clients = get_total_client_number()
+
+    write_files(api_key, env_path, total_clients)
+
+            
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,7 +59,7 @@ Because a local instance of the system should only run for a short period of tim
 
 To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/). 
 
-To make all neccessary files for the clients, dashboard, and the work generator, run `dev_setup.py`.
+To make all neccessary files for the clients, dashboard, and the work generator, run `python dev_setup.py`.
 
 ## Launch Locally
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,39 +59,7 @@ Because a local instance of the system should only run for a short period of tim
 
 To get an api key, visit [here](https://open.gsa.gov/api/regulationsgov/). 
 
-* Create a folder named `env_files`.  
-* In `env_files`, create `client1.env`, `client2.env`, ... up to `client27.env`.  Each file should have the following format:
-
-  ```
-  WORK_SERVER_HOSTNAME=work_server
-  WORK_SERVER_PORT=8080
-  API_KEY=YOUR_KEY
-  ID=CLIENT_NUMBER
-  PYTHONUNBUFFERED=TRUE
-  ```
-  
-  The `PYTHONUNBUFFERED=TRUE` line tells Python to execute `print` statements without buffering (so that we can view logs in realtime).
-
-* In `env_files`, create `work_gen.env` containing: 
-  
-  ```
-  API_KEY=YOUR_KEY
-  PYTHONUNBUFFERED=TRUE
-  ```
-  
-* In `env_files`, create `dashboard.env` containing: 
-  
-  ```
-  MONGO_HOSTNAME=mongo
-  REDIS_HOSTNAME=redis
-  PYTHONUNBUFFERED=TRUE
-  ```
-
-* All data is stored in subfolders of `~/data`.  You must create this folder before launching:
-
-  ```
-  mkdir ~/data
-  ```
+To make all neccessary files for the clients, dashboard, and the work generator, run `dev_setup.py`.
 
 ## Launch Locally
 

--- a/docs/env_files.md
+++ b/docs/env_files.md
@@ -13,9 +13,7 @@ The `PYTHONUNBUFFERED=TRUE` tells Python to output immediately so that we can vi
 ## How to Add New Clients
 To add a new client, 
 
-1. create a new client.env file in the `env_files` directory with the next number for example: `client18.env` be sure to use the same variable names as described above or else the client will error.
-
-2. In the `docker-compose.yaml` file, add the client information in this format at the end of the file to create a new Docker container (client18 is used as an example, in any case use the next highest unused number).
+1. In the `docker-compose.yaml` file, add the client information in this format at the end of the file to create a new Docker container (client18 is used as an example, in any case use the next highest unused number).
 
 		client18:
 		    build:
@@ -23,6 +21,8 @@ To add a new client,
 		      dockerfile: mirrulations-client/Dockerfile
 		    env_file: env_files/client18.env
 		    restart: always
+
+2. Run dev_setup.py to add the new client into `env_files` folder.
 
 ## Error Case
 If a client does not have a corresponding env file the program prints `'need environment variables'` and then closes.

--- a/docs/env_files.md
+++ b/docs/env_files.md
@@ -22,7 +22,7 @@ To add a new client,
 		    env_file: env_files/client18.env
 		    restart: always
 
-2. Run dev_setup.py to add the new client into `env_files` folder.
+2. Run `python dev_setup.py` to add the new client into `env_files` folder.
 
 ## Error Case
 If a client does not have a corresponding env file the program prints `'need environment variables'` and then closes.


### PR DESCRIPTION
I made a script that automates various parts of the development setup. This script will create all files necessary in the env_files directory, and makes the ~/data folder as well. It also knows how many clients are currently in the system so that whenever any new ones are added, this script will update accordingly.  The only input this requires is the user's API key, which can be given through running the script through the terminal.