### PR TITLE
Move jobs_waiting_queue out of Redis and into RabbitMQ

### DIFF
--- a/devup
+++ b/devup
@@ -11,4 +11,4 @@ while getopts 'b' OPTION; do
             ;;
     esac
 done
-docker-compose up -d nginx redis mongo work_generator work_server dashboard client1
+docker-compose up -d nginx rabbitmq redis mongo work_generator work_server dashboard client1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,25 +15,58 @@ services:
     ports:
       - "6379:6379"
     restart: always
+    healthcheck:
+      test: [ "CMD", "redis-cli","ping" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+  rabbitmq:
+    build:
+      context: .
+      dockerfile: mirrulations-rabbitmq/Dockerfile
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:15672" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
   mongo:
     image: mongo
     volumes:
       - "~/data/db:/data/db"
     ports:
       - "27017:27017"
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/test --quiet
+      interval: 10s
+      timeout: 10s
+      retries: 5
   work_generator:
     build:
       context: .
       dockerfile: mirrulations-work-generator/Dockerfile
     depends_on:
-      - redis
-      - mongo
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     env_file: env_files/work_gen.env
     restart: always
   work_server:
     build:
       context: .
       dockerfile: mirrulations-work-server/Dockerfile
+    depends_on:
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     restart: always
     volumes:
       - ~/data/data:/data
@@ -44,6 +77,13 @@ services:
     env_file: env_files/dashboard.env
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
+    depends_on:
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
   client1:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
     build:
       context: .
       dockerfile: mirrulations-rabbitmq/Dockerfile
+    hostname: 'mirrulations-rabbitmq'
+    volumes:
+      - "~/data/rabbitmq:/var/lib/rabbitmq/mnesia"
     ports:
       - "5672:5672"
       - "15672:15672"

--- a/mirrulations-core/setup.cfg
+++ b/mirrulations-core/setup.cfg
@@ -21,5 +21,6 @@ install_requires =
     wheel >= 0.36.2
     pytz >= 2021.1
     pymongo >= 3.11.4
+    pika >= 1.3.1
 [options.packages.find]
 where=src

--- a/mirrulations-core/src/mirrcore/job_queue.py
+++ b/mirrulations-core/src/mirrcore/job_queue.py
@@ -1,9 +1,17 @@
-import json
-from re import S
+from mirrcore.rabbitmq import RabbitMQ
+
+
 class JobQueue:
+    """
+    This class is an abstraction of the process of adding and
+    getting jobs.  It hides the implementation details of
+    how jobs are stored in a DB/memory.
+    """
 
     def __init__(self, database):
         self.database = database
+        self.rabbitmq = RabbitMQ()
+
         if not self.database.exists('num_jobs_attachments_waiting'):
             self.database.set('num_jobs_attachments_waiting', 0)
         if not self.database.exists('num_jobs_comments_waiting'):
@@ -22,9 +30,7 @@ class JobQueue:
             'reg_id': reg_id,
             'agency': agency
             }
-        self.database.lpush('jobs_waiting_queue', json.dumps(job))
-        # reflect change to the queue len in redis db to avoid timeouts from counting true len
-        print(job_type)
+        self.rabbitmq.add(job)
         if job_type == 'attachments':
             self.database.incr('num_jobs_attachments_waiting')
         elif job_type == 'comments':
@@ -33,14 +39,36 @@ class JobQueue:
             self.database.incr('num_jobs_documents_waiting')
         elif job_type == 'dockets':
             self.database.incr('num_jobs_dockets_waiting')
-        
-        
 
     def get_num_jobs(self):
-        return self.database.llen('jobs_waiting_queue')
-    
+        return self.rabbitmq.size()
+
+    def get_job_stats(self):
+        jobs_waiting = self.get_num_jobs()
+        jobs_in_progress = int(self.database.hlen('jobs_in_progress'))
+        jobs_total_minus_jobs_done = jobs_waiting + jobs_in_progress
+
+        client_ids = self.database.get('total_num_client_ids')
+        clients_total = int(client_ids) if client_ids is not None else 0
+
+        return {
+            'num_jobs_waiting': jobs_waiting,
+            'num_jobs_in_progress':
+                int(self.database.hlen('jobs_in_progress')),
+            'jobs_total': jobs_total_minus_jobs_done,
+            'clients_total': clients_total,
+            'num_jobs_attachments_queued':
+                int(self.database.get('num_jobs_attachments_waiting')),
+            'num_jobs_comments_queued':
+                int(self.database.get('num_jobs_comments_waiting')),
+            'num_jobs_documents_queued':
+                int(self.database.get('num_jobs_documents_waiting')),
+            'num_jobs_dockets_queued':
+                int(self.database.get('num_jobs_dockets_waiting'))
+        }
+
     def get_job(self):
-        return json.loads(self.database.lpop('jobs_waiting_queue'))
+        return self.rabbitmq.get()
 
     def get_job_id(self):
         job_id = self.database.incr('last_job_id')

--- a/mirrulations-core/src/mirrcore/rabbitmq.py
+++ b/mirrulations-core/src/mirrcore/rabbitmq.py
@@ -1,0 +1,55 @@
+import pika
+import json
+
+
+def make_channel():
+    """
+    Connections timeout, so we have to create a new one each time we interact
+    with RabbitMQ
+
+    @return: a new channel connected to the jobs_waiting_queue
+    """
+    connection = pika.BlockingConnection(pika.ConnectionParameters('rabbitmq'))
+    channel = connection.channel()
+    channel.queue_declare('jobs_waiting_queue')
+    return channel
+
+
+class RabbitMQ:
+    """
+    Encapsulate calls to RabbitMQ in one place
+    """
+    def add(self, job):
+        """
+        Add a job to the channel
+        @param job: the job to add
+        @return: None
+        """
+        channel = make_channel()
+        channel.basic_publish(exchange='',
+                              routing_key='jobs_waiting_queue',
+                              body=json.dumps(job))
+
+    def size(self):
+        """
+        Get the number of jobs in the queue
+        @return: a non-negative integer
+        """
+        channel = make_channel()
+        queue = channel.queue_declare('jobs_waiting_queue')
+        return queue.method.message_count
+
+    def get(self):
+        """
+        Take one job from the queue and return it
+        @return: a job, or None if there are no jobs
+        """
+        # Connections timeout, so we have to create a new one each time
+        channel = make_channel()
+        method_frame, header_frame, body = channel.basic_get('jobs_waiting_queue')
+        # If there was no job available
+        if method_frame is None:
+            return None
+
+        channel.basic_ack(method_frame.delivery_tag)
+        return json.loads(body.decode('utf-8'))

--- a/mirrulations-core/tests/test_rabbitmq.py
+++ b/mirrulations-core/tests/test_rabbitmq.py
@@ -12,22 +12,22 @@ so this test simply calls all the methods using a mock
 
 class ChannelSpy:
 
-    def queue_declare(self, queue):
+    def queue_declare(self, *args, **kwargs):
         return MagicMock()
 
-    def basic_publish(self, exchange, routing_key, body):
+    def basic_publish(self, *args, **kwargs):
         pass
 
-    def basic_get(self, name):
+    def basic_get(self, *args, **kwargs):
         return None, None, None
 
 
 class PikaSpy:
 
-    def __init__(self, params):
+    def __init__(self, *args, **kwargs):
         self.is_open = True
 
-    def channel(self):
+    def channel(self, *args, **kwargs):
         return ChannelSpy()
 
 

--- a/mirrulations-core/tests/test_rabbitmq.py
+++ b/mirrulations-core/tests/test_rabbitmq.py
@@ -25,7 +25,7 @@ class ChannelSpy:
 class PikaSpy:
 
     def __init__(self, params):
-        pass
+        self.is_open = True
 
     def channel(self):
         return ChannelSpy()

--- a/mirrulations-core/tests/test_rabbitmq.py
+++ b/mirrulations-core/tests/test_rabbitmq.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+from mirrcore.rabbitmq import RabbitMQ
+import pika
+
+"""
+This test exists to increase coverage.  The RabbitMQ class encapsulates
+interactions with RabbitMQ.  We don't need to test the pika class,
+so this test simply calls all the methods using a mock
+"""
+
+
+class ChannelSpy:
+
+    def queue_declare(self, queue):
+        return MagicMock()
+
+    def basic_publish(self, exchange, routing_key, body):
+        pass
+
+    def basic_get(self, name):
+        return None, None, None
+
+
+class PikaSpy:
+
+    def __init__(self, params):
+        pass
+
+    def channel(self):
+        return ChannelSpy()
+
+
+def test_rabbit_interactions(monkeypatch):
+
+    monkeypatch.setattr(pika, 'BlockingConnection', PikaSpy)
+
+    r = RabbitMQ()
+    r.add('foo')
+    r.size()
+    r.get()

--- a/mirrulations-dashboard/Dockerfile
+++ b/mirrulations-dashboard/Dockerfile
@@ -5,7 +5,9 @@ RUN apt-get update; apt-get install docker.io -y
 RUN python3 -m venv .venv
 
 COPY mirrulations-dashboard .
+COPY mirrulations-core /mirrulations-core
 
 RUN .venv/bin/pip install -e .
+RUN .venv/bin/pip install /mirrulations-core
 
 CMD [".venv/bin/gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "120", "-m", "007", "mirrdash.wsgi:app"]

--- a/mirrulations-dashboard/src/mirrdash/dashboard_server.py
+++ b/mirrulations-dashboard/src/mirrdash/dashboard_server.py
@@ -12,6 +12,7 @@ from flask import Flask, jsonify, render_template
 from flask_cors import CORS
 from redis import Redis
 from mirrdash.sum_mongo_counts import connect_mongo_db, get_done_counts
+from mirrcore.job_queue import JobQueue
 from dotenv import load_dotenv
 import docker
 
@@ -26,7 +27,8 @@ class Dashboard:
 
 
 def get_jobs_stats(database):
-    jobs_waiting = int(database.llen('jobs_waiting_queue'))
+    job_queue = JobQueue(database)
+    jobs_waiting = job_queue.get_num_jobs()
     jobs_in_progress = int(database.hlen('jobs_in_progress'))
     jobs_total_minus_jobs_done = jobs_waiting + jobs_in_progress
 
@@ -34,8 +36,7 @@ def get_jobs_stats(database):
     clients_total = int(client_ids) if client_ids is not None else 0
 
     return {
-        'num_jobs_waiting':
-        int(database.llen('jobs_waiting_queue')),
+        'num_jobs_waiting': jobs_waiting,
         'num_jobs_in_progress':
         int(database.hlen('jobs_in_progress')),
         'jobs_total': jobs_total_minus_jobs_done,

--- a/mirrulations-dashboard/src/mirrdash/dashboard_server.py
+++ b/mirrulations-dashboard/src/mirrdash/dashboard_server.py
@@ -10,46 +10,25 @@ Dependencies:
 import os
 from flask import Flask, jsonify, render_template
 from flask_cors import CORS
-from redis import Redis
-from mirrdash.sum_mongo_counts import connect_mongo_db, get_done_counts
+
 from mirrcore.job_queue import JobQueue
+from mirrdash.sum_mongo_counts import connect_mongo_db, get_done_counts
 from dotenv import load_dotenv
+from redis import Redis
 import docker
 
 
 class Dashboard:
-    def __init__(self, redis_server, docker_server, mongo_client):
+    def __init__(self, job_queue, docker_server, mongo_client):
         self.app = Flask(__name__)
-        self.redis = redis_server
+        self.job_queue = job_queue
         self.docker = docker_server
         self.mongo = mongo_client
         CORS(self.app, resources={r'/data': {'origins': '*'}})
 
 
-def get_jobs_stats(database):
-    job_queue = JobQueue(database)
-    jobs_waiting = job_queue.get_num_jobs()
-    jobs_in_progress = int(database.hlen('jobs_in_progress'))
-    jobs_total_minus_jobs_done = jobs_waiting + jobs_in_progress
-
-    client_ids = database.get('total_num_client_ids')
-    clients_total = int(client_ids) if client_ids is not None else 0
-
-    return {
-        'num_jobs_waiting': jobs_waiting,
-        'num_jobs_in_progress':
-        int(database.hlen('jobs_in_progress')),
-        'jobs_total': jobs_total_minus_jobs_done,
-        'clients_total': clients_total,
-        'num_jobs_attachments_queued':
-        int(database.get('num_jobs_attachments_waiting')),
-        'num_jobs_comments_queued':
-        int(database.get('num_jobs_comments_waiting')),
-        'num_jobs_documents_queued':
-        int(database.get('num_jobs_documents_waiting')),
-        'num_jobs_dockets_queued':
-        int(database.get('num_jobs_dockets_waiting'))
-    }
+def get_jobs_stats(job_queue):
+    return job_queue.get_job_stats()
 
 
 def get_container_stats(client):
@@ -73,8 +52,8 @@ def get_container_name(container_name):
     return '_'.join(long_name_lst)
 
 
-def create_server(database, docker_server, mongo_client):
-    dashboard = Dashboard(database, docker_server, mongo_client)
+def create_server(job_queue, docker_server, mongo_client):
+    dashboard = Dashboard(job_queue, docker_server, mongo_client)
 
     @dashboard.app.route('/', methods=['GET'])
     def _index():
@@ -85,8 +64,7 @@ def create_server(database, docker_server, mongo_client):
     @dashboard.app.route('/data', methods=['GET'])
     def _get_dashboard_data():
         """ returns data as json and request status code """
-        # Get the jobs stats in the redis db
-        data = get_jobs_stats(dashboard.redis)
+        data = get_jobs_stats(dashboard.job_queue)
 
         # Get the number of jobs done from the mongo db
         # and add it to the data
@@ -114,7 +92,8 @@ def create_server(database, docker_server, mongo_client):
 if __name__ == '__main__':
     load_dotenv()
     mongo_host = os.getenv('MONGO_HOSTNAME')
-    server = create_server(Redis(os.getenv('REDIS_HOSTNAME')),
+    the_job_queue = JobQueue(Redis(os.getenv('REDIS_HOSTNAME')))
+    server = create_server(the_job_queue,
                            docker.from_env(),
                            connect_mongo_db(mongo_host, 27017))
     server.app.run(port=5000)

--- a/mirrulations-dashboard/src/mirrdash/wsgi.py
+++ b/mirrulations-dashboard/src/mirrdash/wsgi.py
@@ -1,10 +1,13 @@
 import os
 import docker
 from redis import Redis
+
+from mirrcore.job_queue import JobQueue
 from mirrdash.dashboard_server import create_server
 from mirrdash.sum_mongo_counts import connect_mongo_db
 
 mongo_host = os.getenv('MONGO_HOSTNAME')
-server = create_server(Redis('redis'), docker.from_env(),
+job_queue = JobQueue(Redis('redis'))
+server = create_server(job_queue, docker.from_env(),
                        connect_mongo_db(mongo_host, 27017))
 app = server.app

--- a/mirrulations-mocks/src/mirrmock/mock_rabbitmq.py
+++ b/mirrulations-mocks/src/mirrmock/mock_rabbitmq.py
@@ -1,0 +1,13 @@
+class MockRabbit:
+
+    def __init__(self):
+        self.jobs = []
+
+    def add(self, job):
+        self.jobs.append(job)
+
+    def size(self):
+        return len(self.jobs)
+
+    def get(self):
+        return self.jobs.pop(0)

--- a/mirrulations-rabbitmq/Dockerfile
+++ b/mirrulations-rabbitmq/Dockerfile
@@ -1,0 +1,3 @@
+FROM rabbitmq:3.8-management
+
+RUN apt update && apt install -y curl

--- a/mirrulations-work-generator/tests/test_results_processor.py
+++ b/mirrulations-work-generator/tests/test_results_processor.py
@@ -5,6 +5,7 @@ from mirrgen.results_processor import ResultsProcessor
 from mirrcore.job_queue import JobQueue
 from mirrmock.mock_data_storage import MockDataStorage
 from mirrmock.mock_dataset import MockDataSet
+from mirrmock.mock_rabbitmq import MockRabbit
 
 
 def test_process_results():
@@ -12,39 +13,52 @@ def test_process_results():
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
 
-    processor = ResultsProcessor(JobQueue(database), MockDataStorage())
+    queue = JobQueue(database)
+    # mock out the rabbit connection
+    queue.rabbitmq = MockRabbit()
+    processor = ResultsProcessor(queue, MockDataStorage())
     with open(f'{dir_path}/data/dockets_listing.json',
               encoding='utf8') as listings:
         data = listings.read()
         processor.process_results(json.loads(data))
 
-    assert database.llen('jobs_waiting_queue') == 10
+    assert queue.get_num_jobs() == 10
 
 
 def test_one_job_is_added_if_not_a_comment():
     database = FakeRedis()
     results = MockDataSet(1, job_type='dockets').get_results()
-    processor = ResultsProcessor(JobQueue(database), MockDataStorage())
+    queue = JobQueue(database)
+    # mock out the rabbit connection
+    queue.rabbitmq = MockRabbit()
+    processor = ResultsProcessor(queue, MockDataStorage())
     processor.process_results(json.loads(results[0]['text']))
-    assert database.llen('jobs_waiting_queue') == 1
+    assert queue.get_num_jobs() == 1
 
 
 def test_adds_two_jobs_if_is_comment():
     database = FakeRedis()
     results = MockDataSet(1, job_type='comments').get_results()
-    processor = ResultsProcessor(JobQueue(database), MockDataStorage())
+    queue = JobQueue(database)
+    # mock out the rabbit connection
+    queue.rabbitmq = MockRabbit()
+    processor = ResultsProcessor(queue, MockDataStorage())
     processor.process_results(json.loads(results[0]['text']))
-    assert database.llen('jobs_waiting_queue') == 2
+    assert queue.get_num_jobs() == 2
 
 
 def test_job_types_added_if_comment_is_a_comment_type_and_attachment_type():
     database = FakeRedis()
     results = MockDataSet(1, job_type='comments').get_results()
-    processor = ResultsProcessor(JobQueue(database), MockDataStorage())
+    queue = JobQueue(database)
+    # mock out the rabbit connection
+    queue.rabbitmq = MockRabbit()
+    processor = ResultsProcessor(queue, MockDataStorage())
     processor.process_results(json.loads(results[0]['text']))
 
-    job_type_1 = database.lindex('jobs_waiting_queue', 0)
-    job_type_2 = database.lindex('jobs_waiting_queue', 1)
+    job_type_1 = queue.get_job()
+    job_type_2 = queue.get_job()
 
-    assert json.loads(job_type_1.decode())["job_type"] == "attachments"
-    assert json.loads(job_type_2.decode())["job_type"] == "comments"
+    # returned in reverse order
+    assert job_type_2["job_type"] == "attachments"
+    assert job_type_1["job_type"] == "comments"


### PR DESCRIPTION

[https://rabbitmq.com/](https://rabbitmq.com/) is a Message Queue, and it allow us to efficiently manage the jobs waiting.  In the current system we use Redis, which holds all data *in memory.*  As the size of the queue grew, the `capstone` box ran out of memory, and the system crashed.

RabbitMQ is a more appropriate technology for this portion of the system. 

