### PR TITLE
Add basic logging for the work generator

### DIFF
--- a/mirrulations-work-generator/src/mirrgen/results_processor.py
+++ b/mirrulations-work-generator/src/mirrgen/results_processor.py
@@ -20,15 +20,18 @@ class ResultsProcessor:
                 if job_type == 'comments':
                     # updates the url and job_type
                     url = url + '/attachments'
-                    job_type = 'attachments'
                     # adds new attachment job to jobs_waiting_queue
                     reg_id = item['id']
                     agency = reg_id.split('-')[0]
-                    self.job_queue.add_job(url, job_type, reg_id, agency)
-                    count['attachment'] += 1
+                    self.job_queue.add_job(url, 'attachments', reg_id, agency)
+                    counts['attachment'] += 1
             else:
                 counts['preexisting'] += 1
 
-        # join counts into a single string
-        report = ', '.join([f'{key}: {counts[key]}' for key in counts])
-        print(f'Added {report}')
+        print_report(counts)
+
+
+def print_report(counts):
+    # join counts into a single string
+    report = ', '.join([f'{key}: {counts[key]}' for key in counts])
+    print(f'Added {report}')

--- a/mirrulations-work-generator/src/mirrgen/results_processor.py
+++ b/mirrulations-work-generator/src/mirrgen/results_processor.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 
 class ResultsProcessor:
 
@@ -6,6 +8,7 @@ class ResultsProcessor:
         self.data_storage = data_storage
 
     def process_results(self, results_dict):
+        counts = Counter()
         for item in results_dict['data']:
             if not self.data_storage.exists(item):
                 # sets url and job_type
@@ -13,6 +16,7 @@ class ResultsProcessor:
                 job_type = item['type']
                 # adds current job to jobs_waiting_queue
                 self.job_queue.add_job(url, job_type)
+                counts[job_type] += 1
                 if job_type == 'comments':
                     # updates the url and job_type
                     url = url + '/attachments'
@@ -21,3 +25,10 @@ class ResultsProcessor:
                     reg_id = item['id']
                     agency = reg_id.split('-')[0]
                     self.job_queue.add_job(url, job_type, reg_id, agency)
+                    count['attachment'] += 1
+            else:
+                counts['preexisting'] += 1
+
+        # join counts into a single string
+        report = ', '.join([f'{key}: {counts[key]}' for key in counts])
+        print(f'Added {report}')

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -55,9 +55,15 @@ if __name__ == '__main__':
 
         # Download dockets, documents, and comments
         # from all jobs in the job queue
+        print('Begin generate docket jobs')
         generator.download('dockets')
+        print('End generate docket jobs')
+        print('Begin generate document jobs')
         generator.download('documents')
+        print('End generate document jobs')
+        print('Begin generate comment/attachment jobs')
         generator.download('comments')
+        print('End generate commend/attachment jobs')
 
     while True:
         generate_work()

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
         print('End generate document jobs')
         print('Begin generate comment/attachment jobs')
         generator.download('comments')
-        print('End generate commend/attachment jobs')
+        print('End generate comment/attachment jobs')
 
     while True:
         generate_work()


### PR DESCRIPTION
Logging looks like:

```
➜  mirrulations git:(work_gen_logging) ✗ docker-compose logs -ft work_generator
Attaching to mirrulations_work_generator_1
work_generator_1  | 2023-03-02T20:11:00.233280211Z Begin generate docket jobs
work_generator_1  | 2023-03-02T20:11:10.330946300Z Added dockets: 1
work_generator_1  | 2023-03-02T20:11:10.331227175Z End generate docket jobs
work_generator_1  | 2023-03-02T20:11:10.331238966Z Begin generate document jobs
work_generator_1  | 2023-03-02T20:11:16.068664761Z Added documents: 250
work_generator_1  | 2023-03-02T20:11:21.837571763Z Added documents: 250
work_generator_1  | 2023-03-02T20:11:27.557239252Z Added documents: 250
```