### PR TITLE
Fix pylint static analysis recommendation

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -26,5 +26,5 @@ max-returns=4
 max-statements=20
 
 [EXCEPTIONS]
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
I noticed this recommendation when running static analysis. The prompt should be fixed now.
Before:
```
flake8 mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;
pycodestyle mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;
pylint mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.BaseException' ?) instead.
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.

------------------------------------
Your code has been rated at 10.00/10
```
After:
```
flake8 mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;
pycodestyle mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;
pylint mirrulations-client mirrulations-dashboard mirrulations-work-generator mirrulations-work-server;

------------------------------------
Your code has been rated at 10.00/10
```