### PR TITLE
Change mongosh to mongo in test command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - "27017:27017"
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh mongo:27017/test --quiet
+      test: echo 'db.runCommand("ping").ok' | mongo mongo:27017/test --quiet
       interval: 10s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
- The system was having issues coming up in the box. 
- The redis container was failing its health check, crashing the system.
- It was using a mongosh command, which was added in version 6.0.
- We replaced the command with its older version, mongo, and the system came back to life. 
- We may want to consider updating mongo instead of making this change. 