### PR TITLE
Add script to install packages

### DIFF
--- a/dev_setup.py
+++ b/dev_setup.py
@@ -59,6 +59,9 @@ if __name__ == "__main__":
     env_path = create_env_folder() 
     total_clients = get_total_client_number()
 
+    # Install all packages
+    os.system("bash install_packages.sh")
+
     write_files(api_key, env_path, total_clients)
 
             

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,27 +1,7 @@
 
 ## Developer Setup
 
-* Create and activate a virtual environment
-
-  ```
-  python3 -m venv .venv
-  source .venv/bin/activate
-  ```
-
-* Install source code as a module
-
-  The project is organized into multiple modules, which must each be installed as "editable"
-  (using the `-e` switch on `pip`):
-
-  ```
-  pip install -e mirrulations-client
-  pip install -e mirrulations-core
-  pip install -e mirrulations-dashboard
-  pip install -e mirrulations-mocks
-  pip install -e mirrulations-work-generator 
-  pip install -e mirrulations-work-server
-  pip install -e mirrulations-extractor
-  ```
+* Run `python dev_setup.py` to create a virtual environment and install all neccessary packages.
 
 ## Run Static Analysis and Tests
 

--- a/install_packages.sh
+++ b/install_packages.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if [ ! -d "./.venv" ] 
+then
+    python3 -m venv .venv
+
+fi
+
+.venv/bin/pip install -e mirrulations-client
+.venv/bin/pip install -e mirrulations-core
+.venv/bin/pip install -e mirrulations-dashboard
+.venv/bin/pip install -e mirrulations-mocks
+.venv/bin/pip install -e mirrulations-work-generator 
+.venv/bin/pip install -e mirrulations-work-server
+.venv/bin/pip install -e mirrulations-extractor 


### PR DESCRIPTION
I added a shell script to do all necessary pip installs of the components of the system. I felt this was necessary because the number of packages to install was increasing, and any developer would have to  manually do each one. The script will check if a python virtual environment exists, and make it if needed before using pip to do all package installations.