### PR TITLE
make the work generator look for duplication on disk instead of mongo.

### DIFF
--- a/mirrulations-mocks/src/mirrmock/mock_dataset.py
+++ b/mirrulations-mocks/src/mirrmock/mock_dataset.py
@@ -5,7 +5,7 @@ import pytz
 
 class MockDataSet:
 
-    def __init__(self, num_results, job_type='any', start_date='2020-01-01 00:00:00'):
+    def __init__(self, num_results, job_type='dockets', start_date='2020-01-01 00:00:00'):
         utc = pytz.utc
 
         self.start = datetime.datetime.fromisoformat(start_date)\

--- a/mirrulations-work-generator/src/mirrgen/results_processor.py
+++ b/mirrulations-work-generator/src/mirrgen/results_processor.py
@@ -1,16 +1,29 @@
+import os
 from collections import Counter
+from mirrcore.path_generator import PathGenerator
+
+
+def result_exists(search_element):
+    path_generator = PathGenerator()
+    # We are checking search results, but the PathGenerator expects
+    # the actual data of a docket, document, or comment JSON.
+    # But the PathGenerator only needs to type, agency, and other
+    # data that is in the search results.  Therefore, we can simply
+    # wrap the search result in a data field and then use the PathGenerator.
+    fake_result = {'data': search_element}
+    the_path = path_generator.get_path(fake_result)
+    return os.path.exists(the_path)
 
 
 class ResultsProcessor:
 
-    def __init__(self, job_queue, data_storage):
+    def __init__(self, job_queue):
         self.job_queue = job_queue
-        self.data_storage = data_storage
 
     def process_results(self, results_dict):
         counts = Counter()
         for item in results_dict['data']:
-            if not self.data_storage.exists(item):
+            if not result_exists(item):
                 # sets url and job_type
                 url = item['links']['self']
                 job_type = item['type']

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -7,16 +7,15 @@ from mirrgen.results_processor import ResultsProcessor
 from mirrcore.regulations_api import RegulationsAPI
 from mirrcore.job_queue import JobQueue
 from mirrcore.job_queue_exceptions import JobQueueException
-from mirrcore.data_storage import DataStorage
 from mirrcore.redis_check import is_redis_available
 
 
 class WorkGenerator:
 
-    def __init__(self, job_queue, api, datastorage):
+    def __init__(self, job_queue, api):
         self.job_queue = job_queue
         self.api = api
-        self.processor = ResultsProcessor(job_queue, datastorage)
+        self.processor = ResultsProcessor(job_queue)
 
     def download(self, endpoint):
         # Gets the timestamp of the last known job in queue
@@ -50,9 +49,7 @@ if __name__ == '__main__':
 
         job_queue = JobQueue(database)
 
-        storage = DataStorage()
-
-        generator = WorkGenerator(job_queue, api, storage)
+        generator = WorkGenerator(job_queue, api)
 
         # Download dockets, documents, and comments
         # from all jobs in the job queue

--- a/mirrulations-work-generator/tests/test_results_processor.py
+++ b/mirrulations-work-generator/tests/test_results_processor.py
@@ -3,7 +3,6 @@ import os
 from fakeredis import FakeRedis
 from mirrgen.results_processor import ResultsProcessor, print_report
 from mirrcore.job_queue import JobQueue
-from mirrmock.mock_data_storage import MockDataStorage
 from mirrmock.mock_dataset import MockDataSet
 from mirrmock.mock_rabbitmq import MockRabbit
 
@@ -16,7 +15,7 @@ def test_process_results():
     queue = JobQueue(database)
     # mock out the rabbit connection
     queue.rabbitmq = MockRabbit()
-    processor = ResultsProcessor(queue, MockDataStorage())
+    processor = ResultsProcessor(queue)
     with open(f'{dir_path}/data/dockets_listing.json',
               encoding='utf8') as listings:
         data = listings.read()
@@ -31,7 +30,7 @@ def test_job_is_added():
     queue = JobQueue(database)
     # mock out the rabbit connection
     queue.rabbitmq = MockRabbit()
-    processor = ResultsProcessor(queue, MockDataStorage())
+    processor = ResultsProcessor(queue)
     processor.process_results(json.loads(results[0]['text']))
     assert queue.get_num_jobs() == 1
 

--- a/mirrulations-work-generator/tests/test_workgen.py
+++ b/mirrulations-work-generator/tests/test_workgen.py
@@ -3,7 +3,6 @@ from mirrcore.job_queue import JobQueue
 from mirrcore.job_queue_exceptions import JobQueueException
 from mirrcore.regulations_api import RegulationsAPI
 from mirrmock.mock_dataset import MockDataSet
-from mirrmock.mock_data_storage import MockDataStorage
 from mirrmock.mock_rabbitmq import MockRabbit
 from mirrgen.work_generator import WorkGenerator
 import pytest
@@ -20,9 +19,7 @@ def test_work_generator_single_page(requests_mock, mocker):
     # mock out the rabbit connection
     job_queue.rabbitmq = MockRabbit()
 
-    storage = MockDataStorage()
-
-    generator = WorkGenerator(job_queue, api, storage)
+    generator = WorkGenerator(job_queue, api)
     generator.download('documents')
 
     assert job_queue.get_num_jobs() == 150
@@ -39,8 +36,7 @@ def test_work_generator_large(requests_mock, mocker):
     # mock out the rabbit connection
     job_queue.rabbitmq = MockRabbit()
 
-    storage = MockDataStorage()
-    generator = WorkGenerator(job_queue, api, storage)
+    generator = WorkGenerator(job_queue, api)
     generator.download('documents')
 
     assert job_queue.get_num_jobs() == 6666
@@ -58,8 +54,7 @@ def test_work_generator_retries_after_500(requests_mock, mocker):
     # mock out the rabbit connection
     job_queue.rabbitmq = MockRabbit()
 
-    storage = MockDataStorage()
-    generator = WorkGenerator(job_queue, api, storage)
+    generator = WorkGenerator(job_queue, api)
     generator.download('documents')
 
     assert len(requests_mock.request_history) == 2
@@ -85,9 +80,7 @@ def test_work_generator_catches_job_queue_exception(requests_mock, mocker):
     # with a new method that raises the JobQueueException exception
     mocker.patch.object(job_queue, 'add_job', side_effect=JobQueueException())
 
-    storage = MockDataStorage()
-
-    generator = WorkGenerator(job_queue, api, storage)
+    generator = WorkGenerator(job_queue, api)
 
     # Attempt to generate work and ensure that a JobQueueException is raised
     with pytest.raises(JobQueueException):
@@ -105,7 +98,7 @@ def test_work_generator_output_after_500_error(capsys, requests_mock, mocker):
     # mock out the rabbit connection
     job_queue.rabbitmq = MockRabbit()
 
-    generator = WorkGenerator(job_queue, api, MockDataStorage())
+    generator = WorkGenerator(job_queue, api)
     generator.download('documents')
 
     print_data = [
@@ -114,6 +107,6 @@ def test_work_generator_output_after_500_error(capsys, requests_mock, mocker):
         'https://api.regulations.gov/v4/documents?',
         'sort=lastModifiedDate&page[size]=250',
         '&filter[lastModifiedDate][ge]=1971-12-31+19:00:00&page[number]=1\n',
-        'Added any: 150\n'
+        'Added dockets: 150\n'
     ]
     assert capsys.readouterr().out == "".join(print_data)


### PR DESCRIPTION
The work generator checks to see if the data exists before it adds it to the queue.  Previously, this looked at Mongo, which was taking .5 to 1.5 seconds per check.  This made the work generation process too slow - many clients were sitting idle.

This change uses the PathGenerator to compute the path of the resulting file.  Because search results have id, agency, etc., they are close enough that the PathGenerator can compute the path (with a small hack).

This method also allowed us to get rid of the DataStorage class in the work generation process.  This simplifies the interface to these objects in production and in testing.