### PR TITLE
Reduce PathGenerator output.

### DIFF
--- a/mirrulations-core/src/mirrcore/path_generator.py
+++ b/mirrulations-core/src/mirrcore/path_generator.py
@@ -67,8 +67,6 @@ class PathGenerator:
         segments = item_id.split('-') # list of segments separated by '-'
         segments_excluding_end = segments[:-1] # drops the last segment
         parsed_docket_id = '-'.join(segments_excluding_end)
-        print(f'No DocketId Key found, parsing the "id" key')
-        print(f'Id = {item_id}, Parsed DocketId = {parsed_docket_id}')
         return parsed_docket_id
 
 


### PR DESCRIPTION
This removes two output statements when we have to parse a docket it. This output isn't necessary, and it clutters the logs.