### PR TITLE
Remove client 27.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,13 +354,4 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
-  client27:
-    build:
-      context: .
-      dockerfile: mirrulations-client/Dockerfile
-    depends_on:
-      - work_server
-    env_file: env_files/client27.env
-    volumes:
-      - ~/data/data:/data
-    restart: always
+

--- a/mirrulations-dashboard/src/mirrdash/static/index.js
+++ b/mirrulations-dashboard/src/mirrdash/static/index.js
@@ -115,7 +115,6 @@ const updateDeveloperDashboardData = () => {
             client24,
             client25,
             client26,
-            client27,
             nginx,
             mongo,
             redis,
@@ -149,7 +148,6 @@ const updateDeveloperDashboardData = () => {
         updateStatus('client24-status', client24)
         updateStatus('client25-status', client25)
         updateStatus('client26-status', client26)
-        updateStatus('client27-status', client27)
         updateStatus('nginx-status', nginx)
         updateStatus('mongo-status', mongo)
         updateStatus('redis-status', redis);

--- a/mirrulations-dashboard/src/mirrdash/templates/dev.html
+++ b/mirrulations-dashboard/src/mirrdash/templates/dev.html
@@ -266,14 +266,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="card header-card">
-                            <div class="info-container">
-                                <div class="info-container-data">
-                                    <h3>Client 27</h3>
-                                    <span id="client27-status">0</span>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
My API was being used in the work generator, causing 429 errors when I ran it locally.  This deletes client 27 so we can use its key for the work generator.