### PR TITLE
Remove print statement from path_generator

### DIFF
--- a/mirrulations-core/src/mirrcore/path_generator.py
+++ b/mirrulations-core/src/mirrcore/path_generator.py
@@ -100,7 +100,6 @@ class PathGenerator:
 
             if docket_id is None:
                 docket_id = self.parse_docket_id(item_i_d)
-                print(f'{item_i_d} was parsed to get docket id: {docket_id}.')
         if not is_docket and item_i_d is None:
             item_i_d = 'unknown'
         docket_id, agency_id = self._check_for_none_values(docket_id,
@@ -133,8 +132,7 @@ class PathGenerator:
                f'{item_i_d}.json'
 
     def _has_file_formats(self, attributes, attachment):
-        if attributes["fileFormats"] and attributes["fileFormats"] \
-                    != "null" and attributes["fileFormats"] is not None:
+        if attributes.get("fileFormats"):
             return True
         print("fileFormats did not exist for attachment ID: " +
               f"{attachment.get('id')}")

--- a/mirrulations-core/tests/test_path_generator.py
+++ b/mirrulations-core/tests/test_path_generator.py
@@ -409,6 +409,24 @@ def test_attachment_comment_paths(generator):
     assert expected_path == generator.get_attachment_json_paths(json_pls)
 
 
+def test_null_file_format_for_attachment_comment_returns_nothing(generator):
+    comment_json = {
+        "data": {
+            "id": "FDA-2017-D-2335-1566",
+            "type": "comments",
+            "attributes": {
+                "agencyId": "FDA",
+                "docketId": "FDA-2017-D-2335"
+            }
+        },
+        "included": [{
+            "attributes": {
+                "fileFormats": None  # A file format with No attachments
+            }
+        }]}
+    assert generator.get_attachment_json_paths(comment_json) == []
+
+
 def test_extractor_save_path():
     path = "/data/data/USTR/USTR-2015-0010/" + \
            "binary-USTR-2015-0010/" + \


### PR DESCRIPTION
Work_generator logs were being cluttered so I removed a print statement coming from the path_generator regarding parsing