### PR TITLE
Removing client 26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,14 +344,3 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
-  client26:
-    build:
-      context: .
-      dockerfile: mirrulations-client/Dockerfile
-    depends_on:
-      - work_server
-    env_file: env_files/client26.env
-    volumes:
-      - ~/data/data:/data
-    restart: always
-

--- a/mirrulations-dashboard/src/mirrdash/static/index.js
+++ b/mirrulations-dashboard/src/mirrdash/static/index.js
@@ -114,7 +114,6 @@ const updateDeveloperDashboardData = () => {
             client23,
             client24,
             client25,
-            client26,
             nginx,
             mongo,
             redis,
@@ -148,7 +147,6 @@ const updateDeveloperDashboardData = () => {
         updateStatus('client23-status', client23)
         updateStatus('client24-status', client24)
         updateStatus('client25-status', client25)
-        updateStatus('client26-status', client26)
         updateStatus('nginx-status', nginx)
         updateStatus('mongo-status', mongo)
         updateStatus('redis-status', redis);

--- a/mirrulations-dashboard/src/mirrdash/templates/dev.html
+++ b/mirrulations-dashboard/src/mirrdash/templates/dev.html
@@ -266,14 +266,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="card header-card">
-                            <div class="info-container">
-                                <div class="info-container-data">
-                                    <h3>Client 26</h3>
-                                    <span id="client26-status">0</span>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request is to remove client 26. Its API key will be used in the job validator. 