### PR TITLE
Add extracted text to MongoDB

### DIFF
--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -8,6 +8,7 @@ class DataStorage:
         self.documents = database['documents']
         self.comments = database['comments']
         self.attachments = database['attachments']
+        self.extraction = database['extracted_text']
 
     def exists(self, search_element):
         result_id = search_element['id']
@@ -30,3 +31,12 @@ class DataStorage:
         entry = {'path': data['attachment_path'],
                  'file': data['attachment_filename']}
         self.attachments.insert_one(entry)
+
+    def add_extracted_text(self, data):
+        """
+        Add extracted text to MongoDB
+        """
+        entry = {
+            'filename': data['filename'],
+            'extracted_text': data['extracted_text']}
+        self.extraction.insert_one(entry)

--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -35,8 +35,11 @@ class DataStorage:
     def add_extracted_text(self, data):
         """
         Add extracted text to MongoDB
+
+        data:
+            data = {
+                'filename': save_path.split("/")[-1],
+                'extracted_text': text
+            }
         """
-        entry = {
-            'filename': data['filename'],
-            'extracted_text': data['extracted_text']}
-        self.extraction.insert_one(entry)
+        self.extraction.insert_one(data)

--- a/mirrulations-core/src/mirrcore/data_storage.py
+++ b/mirrulations-core/src/mirrcore/data_storage.py
@@ -8,7 +8,7 @@ class DataStorage:
         self.documents = database['documents']
         self.comments = database['comments']
         self.attachments = database['attachments']
-        self.extraction = database['extracted_text']
+        self.extraction = database['comments_extracted_text']
 
     def exists(self, search_element):
         result_id = search_element['id']

--- a/mirrulations-core/tests/test_data_storage.py
+++ b/mirrulations-core/tests/test_data_storage.py
@@ -200,11 +200,8 @@ def test_add_text_extraction(monkeypatch):
     monkeypatch.setattr(storage, 'extraction', MockDB())
 
     to_insert = {
-        'data': {
-            'id': 'COMM-2020-1234',
-            'extracted_filename': 'COMM-2020-1234_attachment_1_extracted.txt',
-            'extracted_text': 'foo'
-        },
+        'filename': 'COMM-2020-1234_attachment_1_extracted.txt',
+        'extracted_text': 'foo'
     }
 
     storage.add_extracted_text(to_insert)

--- a/mirrulations-core/tests/test_data_storage.py
+++ b/mirrulations-core/tests/test_data_storage.py
@@ -192,3 +192,21 @@ def test_add_attachment(monkeypatch):
     assert len(storage.documents.saved) == 0
     assert len(storage.comments.saved) == 0
     assert len(storage.attachments.saved) == 1
+
+
+def test_add_text_extraction(monkeypatch):
+    storage = DataStorage()
+
+    monkeypatch.setattr(storage, 'extraction', MockDB())
+
+    to_insert = {
+        'data': {
+            'id': 'COMM-2020-1234',
+            'extracted_filename': 'COMM-2020-1234_attachment_1_extracted.txt',
+            'extracted_text': 'foo'
+        },
+    }
+
+    storage.add_extracted_text(to_insert)
+
+    assert len(storage.extraction.saved) == 1

--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -66,7 +66,7 @@ class Extractor:
             print(f"FAILURE: failed to save {attachment_path}\n{err}")
             return
         text = pdfminer.high_level.extract_text(pdf_bytes)
-        # write to Mongo
+        # write to database
         Extractor.add_extraction_to_database(save_path, text)
         # Make dirs if they do not already exist
         os.makedirs(save_path[:save_path.rfind('/')], exist_ok=True)

--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -10,6 +10,7 @@ from mirrcore.data_storage import DataStorage
 
 
 class Extractor:
+    storage = DataStorage()
     """
     Class containing methods to extract text from files.
     """
@@ -66,7 +67,7 @@ class Extractor:
             return
         text = pdfminer.high_level.extract_text(pdf_bytes)
         # write to Mongo
-        Extractor.add_to_database(save_path, text)
+        Extractor.add_extraction_to_database(save_path, text)
         # Make dirs if they do not already exist
         os.makedirs(save_path[:save_path.rfind('/')], exist_ok=True)
         # Save the extracted text to a file
@@ -75,7 +76,7 @@ class Extractor:
         print(f"SUCCESS: Saved extraction at {save_path}")
 
     @staticmethod
-    def add_to_database(save_path, text):
+    def add_extraction_to_database(save_path, text):
         """
         Add extracted text to database
 
@@ -90,12 +91,11 @@ class Extractor:
             'filename': save_path.split("/")[-1],
             'extracted_text': text
         }
-        storage.add_extracted_text(data)
+        Extractor.storage.add_extracted_text(data)
 
 
 if __name__ == '__main__':
     now = datetime.now()
-    storage = DataStorage()
     while True:
         for (root, dirs, files) in os.walk('/data'):
             for file in files:

--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -6,6 +6,7 @@ import pdfminer
 import pdfminer.high_level
 import pikepdf
 from mirrcore.path_generator import PathGenerator
+from mirrcore.data_storage import DataStorage
 
 
 class Extractor:
@@ -64,6 +65,8 @@ class Extractor:
             print(f"FAILURE: failed to save {attachment_path}\n{err}")
             return
         text = pdfminer.high_level.extract_text(pdf_bytes)
+        # write to Mongo
+        Extractor.add_to_database(save_path, text)
         # Make dirs if they do not already exist
         os.makedirs(save_path[:save_path.rfind('/')], exist_ok=True)
         # Save the extracted text to a file
@@ -71,9 +74,28 @@ class Extractor:
             out_file.write(text.strip())
         print(f"SUCCESS: Saved extraction at {save_path}")
 
+    @staticmethod
+    def add_to_database(save_path, text):
+        """
+        Add extracted text to database
+
+        PARAMETERS
+        -----------
+        save path : str
+            Provides the filename of how it will be saved on Disk
+        extracted_text
+            The text that was extracted from the attachment
+        """
+        data = {
+            'filename': save_path.split("/")[-1],
+            'extracted_text': text
+        }
+        storage.add_extracted_text(data)
+
 
 if __name__ == '__main__':
     now = datetime.now()
+    storage = DataStorage()
     while True:
         for (root, dirs, files) in os.walk('/data'):
             for file in files:

--- a/mirrulations-mocks/src/mirrmock/mock_data_storage.py
+++ b/mirrulations-mocks/src/mirrmock/mock_data_storage.py
@@ -4,6 +4,7 @@ class MockDataStorage:
     def __init__(self):
         self.added = []
         self.attachments_added = []
+        self.extractions = []
 
     def exists(self, search_element=None):
         if search_element is not None:
@@ -15,3 +16,6 @@ class MockDataStorage:
 
     def add_attachment(self, data):
         self.attachments_added.append(data)
+
+    def add_extraction_to_database(self, *args):
+        self.extractions.append(args)


### PR DESCRIPTION
Modified DataStorage class to include text extraction. The table extracted_text gets added to during the extraction process. Currently providing the filename and text to Mongo.

This will help to determine how many attachments the system has extracted text from. Furthermore, will be of use for upcoming changes to Client dashboard to display the extraction progress.