### PR TITLE
Add start_period to give Mongo time to spin up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
+      start_period: 45s
   work_generator:
     build:
       context: .


### PR DESCRIPTION
The start_period addition to the docker compose file will give mongo time to spin up and load the data before the health check begins. I may help keep the container healthy, but the time will need some adjustment. 