### PR TITLE
Move data validator save path for missing jobs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
     env_file: env_files/validator.env
     restart: always
     volumes:
-      - "./:/app/validator"
+      - "~/data:/data"
   work_server:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,9 +67,12 @@ services:
       context: .
       dockerfile: mirrulations-validation/Dockerfile
     depends_on:
-      - redis
-      - mongo
-      - work_generator
+      redis:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     env_file: env_files/validator.env
     restart: always
     volumes:

--- a/mirrulations-validation/src/mirrval/job_validator.py
+++ b/mirrulations-validation/src/mirrval/job_validator.py
@@ -44,7 +44,7 @@ def write_unfound_jobs(res, unfound_jobs):
     else:
         unfound_jobs[f"missing_{res['type']}"].append(
             res['links']['self'])
-    with open("validator/unfound_jobs.json", "w+",
+    with open("/data/unfound_jobs.json", "w+",
               encoding="utf-8") as outfile:
         json.dump(unfound_jobs, outfile, indent=4)
 


### PR DESCRIPTION
I moved the validator to save the missing jobs in a json file. Originally, it was saving the file within the system itself, but now it will save to the data folder along with all downloaded and extracted data.