### PR TITLE
Check for missing jobs in validator JSON file before writing to it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     env_file: env_files/validator.env
     restart: always
     volumes:
-      - "~/data:/data"
+      - "/data:/data"
   work_server:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     env_file: env_files/validator.env
     restart: always
     volumes:
-      - "/data:/data"
+      - "~/data/validator:/data"
   work_server:
     build:
       context: .

--- a/mirrulations-validation/src/mirrval/job_validator.py
+++ b/mirrulations-validation/src/mirrval/job_validator.py
@@ -49,14 +49,15 @@ def write_unfound_jobs(res, unfound_jobs):
               encoding="utf-8") as outfile:
         json.dump(unfound_jobs, outfile, indent=4)
 
+
 def check_for_missing_jobs(res):
     with open("/data/unfound_jobs.json", "r",
               encoding="utf-8") as outfile:
-            lines = outfile.readlines()
-            for line in lines:
-                if res['links']['self'] in line:
-                    return True
-            return False
+        lines = outfile.readlines()
+        for line in lines:
+            if res['links']['self'] in line:
+                return True
+        return False
 
 
 def generate_work(collection=None):

--- a/mirrulations-validation/src/mirrval/job_validator.py
+++ b/mirrulations-validation/src/mirrval/job_validator.py
@@ -42,11 +42,21 @@ def write_unfound_jobs(res, unfound_jobs):
     if f"missing_{res['type']}" not in unfound_jobs:
         unfound_jobs[f"missing_{res['type']}"] = [res['links']['self']]
     else:
-        unfound_jobs[f"missing_{res['type']}"].append(
-            res['links']['self'])
+        if not check_for_missing_jobs(res):
+            unfound_jobs[f"missing_{res['type']}"].append(
+                        res['links']['self'])
     with open("/data/unfound_jobs.json", "w+",
               encoding="utf-8") as outfile:
         json.dump(unfound_jobs, outfile, indent=4)
+
+def check_for_missing_jobs(res):
+    with open("/data/unfound_jobs.json", "r",
+              encoding="utf-8") as outfile:
+            lines = outfile.readlines()
+            for line in lines:
+                if res['links']['self'] in line:
+                    return True
+            return False
 
 
 def generate_work(collection=None):

--- a/mirrulations-validation/src/mirrval/job_validator.py
+++ b/mirrulations-validation/src/mirrval/job_validator.py
@@ -45,13 +45,13 @@ def write_unfound_jobs(res, unfound_jobs):
         if not check_for_missing_jobs(res):
             unfound_jobs[f"missing_{res['type']}"].append(
                         res['links']['self'])
-    with open("/data/unfound_jobs.json", "w+",
+    with open("/data/validator/unfound_jobs.json", "w+",
               encoding="utf-8") as outfile:
         json.dump(unfound_jobs, outfile, indent=4)
 
 
 def check_for_missing_jobs(res):
-    with open("/data/unfound_jobs.json", "r",
+    with open("/data/validator/unfound_jobs.json", "r",
               encoding="utf-8") as outfile:
         lines = outfile.readlines()
         for line in lines:


### PR DESCRIPTION
We realized that the if the validator gets shut down in the middle of it's process, it will duplicate jobs that already exist in the missing_jobs JSON file. To solve this, I have the validator check the file to see if those jobs are in there, and those jobs will not be rewritten if they are in the file already.

This is not ready to be merged until we make a soft link in the data folder.