### PR TITLE
Refactor Duplicate Code for Loading Redis

### DIFF
--- a/mirrulations-core/src/mirrcore/redis_check.py
+++ b/mirrulations-core/src/mirrcore/redis_check.py
@@ -1,3 +1,4 @@
+import time
 import redis
 
 
@@ -6,3 +7,18 @@ def is_redis_available(database):
         return database.ping()
     except (ConnectionRefusedError, redis.BusyLoadingError):
         return False
+
+
+def load_redis(wait_time=30):
+    '''
+    Returns an instance of a Redis client.
+    Blocks until Redis is confirmed to be running.
+    wait_time: number of seconds to wait before checking if Redis is available.
+    '''
+    database = redis.Redis('redis')
+
+    while is_redis_available(database) is False:
+        print('Redis database is busy loading')
+        time.sleep(wait_time)
+
+    return database

--- a/mirrulations-core/tests/test_is_redis_available.py
+++ b/mirrulations-core/tests/test_is_redis_available.py
@@ -1,6 +1,7 @@
 
-from mirrcore.redis_check import is_redis_available
+from mirrcore.redis_check import is_redis_available, load_redis
 from mirrmock.mock_redis import BusyRedis, ReadyRedis
+from unittest.mock import patch
 
 
 def test_when_redis_loading_is_unavailable():
@@ -13,3 +14,15 @@ def test_when_redis_done_loading_is_available():
     database = ReadyRedis()
     is_available = is_redis_available(database)
     assert is_available is True
+
+
+@patch('mirrcore.redis_check.is_redis_available', return_value=False)
+@patch('time.sleep', return_value=None)
+def test_sleeps_when_redis_is_unavailable(patched_available, patched_sleep):
+    def side_effect(x):
+        patched_available.return_value = True
+    patched_sleep.side_effect = side_effect
+
+    load_redis()
+
+    patched_sleep.assert_called_once()

--- a/mirrulations-core/tests/test_is_redis_available.py
+++ b/mirrulations-core/tests/test_is_redis_available.py
@@ -1,7 +1,7 @@
 
+from unittest.mock import patch
 from mirrcore.redis_check import is_redis_available, load_redis
 from mirrmock.mock_redis import BusyRedis, ReadyRedis
-from unittest.mock import patch
 
 
 def test_when_redis_loading_is_unavailable():
@@ -19,7 +19,7 @@ def test_when_redis_done_loading_is_available():
 @patch('mirrcore.redis_check.is_redis_available', return_value=False)
 @patch('time.sleep', return_value=None)
 def test_sleeps_when_redis_is_unavailable(patched_available, patched_sleep):
-    def side_effect(x):
+    def side_effect(_):
         patched_available.return_value = True
     patched_sleep.side_effect = side_effect
 

--- a/mirrulations-validation/src/mirrval/job_validator.py
+++ b/mirrulations-validation/src/mirrval/job_validator.py
@@ -4,9 +4,8 @@ import time
 from collections import Counter
 import json
 from dotenv import load_dotenv
-import redis
 from mirrgen.search_iterator import SearchIterator
-from mirrcore.redis_check import is_redis_available
+# from mirrcore.redis_check import load_redis
 from mirrcore.regulations_api import RegulationsAPI
 from mirrcore.data_storage import DataStorage
 
@@ -61,12 +60,10 @@ def check_for_missing_jobs(res):
 
 
 def generate_work(collection=None):
+    # commented out for static analysis reasons since
+    # the variable 'database' isn't being used.
+    # database = load_redis()
 
-    database = redis.Redis('redis')
-    # Sleep for 30 seconds to give time to load
-    while not is_redis_available(database):
-        print("Redis database is busy loading")
-        time.sleep(30)
     # Get API key
     load_dotenv()
     api = RegulationsAPI(os.getenv("API_KEY"))

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -1,13 +1,12 @@
 import os
 import time
 import dotenv
-import redis
 from mirrgen.search_iterator import SearchIterator
 from mirrgen.results_processor import ResultsProcessor
 from mirrcore.regulations_api import RegulationsAPI
 from mirrcore.job_queue import JobQueue
 from mirrcore.job_queue_exceptions import JobQueueException
-from mirrcore.redis_check import is_redis_available
+from mirrcore.redis_check import load_redis
 
 
 class WorkGenerator:
@@ -40,12 +39,7 @@ if __name__ == '__main__':
         dotenv.load_dotenv()
         api = RegulationsAPI(os.getenv('API_KEY'))
 
-        # Checks if redis database is available
-        database = redis.Redis('redis')
-        # Sleep for 30 seconds to give time to load
-        while not is_redis_available(database):
-            print("Redis database is busy loading")
-            time.sleep(30)
+        database = load_redis()
 
         job_queue = JobQueue(database)
 

--- a/mirrulations-work-server/src/mirrserver/wsgi.py
+++ b/mirrulations-work-server/src/mirrserver/wsgi.py
@@ -1,11 +1,6 @@
-import time
-import redis
 from mirrserver.work_server import create_server
-from mirrcore.redis_check import is_redis_available
+from mirrcore.redis_check import load_redis
 
-database = redis.Redis('redis')
-while not is_redis_available(database):
-    print("Redis database is busy loading")
-    time.sleep(30)
+database = load_redis()
 server = create_server(database)
 app = server.app


### PR DESCRIPTION
Code to load Redis is duplicated in several (3 different) packages:
[mirrulations-validation/src/mirrval/job_validator.py](https://github.com/MoravianUniversity/mirrulations/blob/f822001c8cffef74d74b0a8b497832fd066946a0/mirrulations-validation/src/mirrval/job_validator.py)
[mirrulations-work-generator/src/mirrgen/work_generator.py](https://github.com/MoravianUniversity/mirrulations/blob/fd73db0a6fcf951f35d08e457ece2548beed8f46/mirrulations-work-generator/src/mirrgen/work_generator.py)
[mirrulations-work-server/src/mirrserver/wsgi.py](https://github.com/MoravianUniversity/mirrulations/blob/3a4331b8fdab41a12f33c4e0e14bb9bf4de4caa8/mirrulations-work-server/src/mirrserver/wsgi.py)
