### PR TITLE
Text extraction error handling

### DIFF
--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -63,7 +63,12 @@ class Extractor:
         except (RuntimeError, pikepdf.PdfError) as err:
             print(f"FAILURE: failed to save {attachment_path}\n{err}")
             return
-        text = pdfminer.high_level.extract_text(pdf_bytes)
+        try:
+            text = pdfminer.high_level.extract_text(pdf_bytes)
+        except Exception as err:
+            print(f"FAILURE: failed to extract \
+                  text from {attachment_path}\n{err}")
+            return
         # Make dirs if they do not already exist
         os.makedirs(save_path[:save_path.rfind('/')], exist_ok=True)
         # Save the extracted text to a file

--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -65,9 +65,9 @@ class Extractor:
             return
         try:
             text = pdfminer.high_level.extract_text(pdf_bytes)
-        except Exception as err:
-            print(f"FAILURE: failed to extract \
-                  text from {attachment_path}\n{err}")
+        except ValueError as err:
+            print("FAILURE: failed to extract "
+                  f"text from {attachment_path}\n{err}")
             return
         # Make dirs if they do not already exist
         os.makedirs(save_path[:save_path.rfind('/')], exist_ok=True)

--- a/mirrulations-extractor/tests/test_extractor.py
+++ b/mirrulations-extractor/tests/test_extractor.py
@@ -36,6 +36,14 @@ def test_save_pdf_throws_runtime_error(mocker, capfd):
     assert "FAILURE: failed to save" in capfd.readouterr()[0]
 
 
+def test_text_extraction_throws_error(mocker, capfd):
+    mocker.patch('pikepdf.open', return_value=pikepdf.Pdf.new())
+    mocker.patch('pikepdf.Pdf.save', return_value=None)
+    mocker.patch('pdfminer.high_level.extract_text', side_effect=ValueError)
+    Extractor.extract_text('a.pdf', 'b.txt')
+    assert "FAILURE: failed to extract text from" in capfd.readouterr()[0]
+
+
 def test_extract_pdf(mocker, capfd):
     mocker.patch('pikepdf.open', return_value=pikepdf.Pdf.new())
     mocker.patch('pikepdf.Pdf.save', return_value=None)


### PR DESCRIPTION
Pdfminer.six threw an error when extracting text from a PDF.
It was an internal error and out of our control. The only way afaik to fix this is to flatten the PDF followed by OCR.