### PR TITLE
Redis to get jobs done counts instead of Mongo

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -127,16 +127,15 @@ class Client:
         print(f'Sending Job {job["job_id"]} to Work Server')
         if 'error' not in job_result:
             data['directory'] = self.path_generator.get_path(job_result)
+            self.cache.increase_jobs_done(data['job_type'])
 
         self._put_results(data)
         self.put_results(data)
-        self.cache.increase_jobs_done(data['job_type'])
         comment_has_attachment = self.does_comment_have_attachment(job_result)
         json_has_file_format = self._document_has_file_formats(job_result)
 
         if data["job_type"] == "comments" and comment_has_attachment:
             self.download_all_attachments_from_comment(data, job_result)
-            self.cache.increase_jobs_done('attachment')
         if data["job_type"] == "documents" and json_has_file_format:
             document_htm = self._get_document_htm(job_result)
             if document_htm is not None:
@@ -225,6 +224,7 @@ class Client:
                     print(f"Downloaded {counter+1}/{len(path_list)} "
                           f"attachment(s) for {comment_id_str}")
                     counter += 1
+                    self.cache.increase_jobs_done('attachment')
 
     def download_single_attachment(self, url, path, data):
         '''

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -65,11 +65,8 @@ class Client:
         self.client_id = os.getenv('ID')
         self.path_generator = PathGenerator()
         self.saver = Saver()
-<<<<<<< HEAD
         self.cache = JobStatistics(cache_server)
-=======
         self.bucket_name = "mirrulations"
->>>>>>> 3d98537e52fcb8dd56a8a3c8c7949e357b28fe64
 
         hostname = os.getenv('WORK_SERVER_HOSTNAME')
         port = os.getenv('WORK_SERVER_PORT')

--- a/mirrulations-core/src/mirrcore/jobs_statistics.py
+++ b/mirrulations-core/src/mirrcore/jobs_statistics.py
@@ -23,14 +23,14 @@ class JobStatistics:
 
     def get_jobs_done(self):
         dockets = int(self.cache.get(DOCKETS_DONE))
-        documnets = int(self.cache.get(DOCUMENTS_DONE))
+        documents = int(self.cache.get(DOCUMENTS_DONE))
         comments = int(self.cache.get(COMMENTS_DONE))
         attachments = int(self.cache.get(ATTACHMENTS_DONE))
 
         return {
-            'num_jobs_done': dockets + documnets + comments + attachments,
+            'num_jobs_done': dockets + documents + comments + attachments,
             DOCKETS_DONE: dockets,
-            DOCUMENTS_DONE: documnets,
+            DOCUMENTS_DONE: documents,
             COMMENTS_DONE: comments,
             ATTACHMENTS_DONE: attachments
         }

--- a/mirrulations-core/src/mirrcore/jobs_statistics.py
+++ b/mirrulations-core/src/mirrcore/jobs_statistics.py
@@ -1,0 +1,49 @@
+import redis
+
+DOCKETS_DONE = "num_dockets_done"
+DOCUMENTS_DONE = "num_documents_done"
+COMMENTS_DONE = "num_comments_done"
+ATTACHMENTS_DONE = 'num_attachments_done'
+
+
+class JobStatistics:
+
+    def __init__(self):
+        self.url = "https://api.regulations.gov/v4"
+        self.cache = redis.Redis('redis')
+
+        self._check_keys_exist()
+
+    def _check_keys_exist(self):
+        if not self.cache.exists(DOCKETS_DONE):
+            self.cache.set(DOCKETS_DONE, 0)
+        if not self.cache.exists(DOCUMENTS_DONE):
+            self.cache.set(DOCUMENTS_DONE, 0)
+        if not self.cache.exists(COMMENTS_DONE):
+            self.cache.set(COMMENTS_DONE, 0)
+        if not self.cache.exists(ATTACHMENTS_DONE):
+            self.cache.set(ATTACHMENTS_DONE, 0)
+
+    def get_jobs_done(self):
+        dockets = int(self.cache.get(DOCKETS_DONE))
+        documnets = int(self.cache.get(DOCUMENTS_DONE))
+        comments = int(self.cache.get(COMMENTS_DONE))
+        attachments = int(self.cache.get(ATTACHMENTS_DONE))
+
+        return {
+            'num_jobs_done': dockets + documnets + comments + attachments,
+            DOCKETS_DONE: dockets,
+            DOCUMENTS_DONE: documnets,
+            COMMENTS_DONE: comments,
+            ATTACHMENTS_DONE: attachments
+        }
+
+    def increase_jobs_done(self, job_type):
+        if job_type == "dockets":
+            self.cache.incr(DOCKETS_DONE)
+        elif job_type == 'documents':
+            self.cache.incr(DOCKETS_DONE)
+        elif job_type == 'comments':
+            self.cache.incr(COMMENTS_DONE)
+        elif job_type == 'attachment':
+            self.cache.incr(ATTACHMENTS_DONE)

--- a/mirrulations-core/src/mirrcore/jobs_statistics.py
+++ b/mirrulations-core/src/mirrcore/jobs_statistics.py
@@ -39,7 +39,7 @@ class JobStatistics:
         if job_type == "dockets":
             self.cache.incr(DOCKETS_DONE)
         elif job_type == 'documents':
-            self.cache.incr(DOCKETS_DONE)
+            self.cache.incr(DOCUMENTS_DONE)
         elif job_type == 'comments':
             self.cache.incr(COMMENTS_DONE)
         elif job_type == 'attachment':

--- a/mirrulations-core/src/mirrcore/jobs_statistics.py
+++ b/mirrulations-core/src/mirrcore/jobs_statistics.py
@@ -1,5 +1,3 @@
-import redis
-
 DOCKETS_DONE = "num_dockets_done"
 DOCUMENTS_DONE = "num_documents_done"
 COMMENTS_DONE = "num_comments_done"
@@ -8,9 +6,8 @@ ATTACHMENTS_DONE = 'num_attachments_done'
 
 class JobStatistics:
 
-    def __init__(self):
-        self.url = "https://api.regulations.gov/v4"
-        self.cache = redis.Redis('redis')
+    def __init__(self, cache):
+        self.cache = cache
 
         self._check_keys_exist()
 

--- a/mirrulations-dashboard/src/mirrdash/wsgi.py
+++ b/mirrulations-dashboard/src/mirrdash/wsgi.py
@@ -4,10 +4,8 @@ from redis import Redis
 
 from mirrcore.job_queue import JobQueue
 from mirrdash.dashboard_server import create_server
-from mirrdash.sum_mongo_counts import connect_mongo_db
 
 mongo_host = os.getenv('MONGO_HOSTNAME')
 job_queue = JobQueue(Redis('redis'))
-server = create_server(job_queue, docker.from_env(),
-                       connect_mongo_db(mongo_host, 27017))
+server = create_server(job_queue, docker.from_env())
 app = server.app

--- a/mirrulations-dashboard/src/mirrdash/wsgi.py
+++ b/mirrulations-dashboard/src/mirrdash/wsgi.py
@@ -6,6 +6,7 @@ from mirrcore.job_queue import JobQueue
 from mirrdash.dashboard_server import create_server
 
 mongo_host = os.getenv('MONGO_HOSTNAME')
-job_queue = JobQueue(Redis('redis'))
-server = create_server(job_queue, docker.from_env())
+redis = Redis('redis')
+job_queue = JobQueue(redis)
+server = create_server(job_queue, docker.from_env(), redis)
 app = server.app

--- a/mirrulations-mocks/src/mirrmock/mock_job_statistics.py
+++ b/mirrulations-mocks/src/mirrmock/mock_job_statistics.py
@@ -1,0 +1,7 @@
+from mirrmock.mock_redis import MockRedisWithStorage
+
+
+class MockJobStatistics:
+
+    def __init__(self):
+        self.cache = MockRedisWithStorage()

--- a/mirrulations-work-server/src/mirrserver/work_server.py
+++ b/mirrulations-work-server/src/mirrserver/work_server.py
@@ -1,6 +1,5 @@
 from flask import Flask, json, jsonify, request
 import redis
-from mirrcore.data_storage import DataStorage
 from mirrcore.job_queue import JobQueue
 from mirrcore.job_queue_exceptions import JobQueueException
 from mirrserver.put_results_validator import PutResultsValidator
@@ -48,7 +47,6 @@ class WorkServer:
         """
         self.app = Flask(__name__)
         self.redis = redis_server
-        self.data = DataStorage()
         self.put_results_validator = PutResultsValidator()
         self.get_job_validator = GetJobValidator()
         self.job_queue = JobQueue(redis_server)
@@ -189,7 +187,6 @@ def put_results(workserver, data):
     workserver.redis.hdel('jobs_in_progress', job_id)
     print(f"Wrote job {data['directory'].split('/')[-1]},"
           f" job_id: {job_id}, to {data['directory']}")
-    workserver.data.add(data['results'])
     print(f'SUCCESS: client:{client_id}, job: {job_id}')
     return (True,)
 
@@ -225,7 +222,6 @@ def put_attachment_results(workserver, data):
     if data.get('results') is not None:
         print(f'Attachment from Comment {data["reg_id"]} \
         saved to {data["attachment_path"]}')
-    workserver.data.add_attachment(data)
     return (True,)
 
 

--- a/mirrulations-work-server/tests/test_work_server.py
+++ b/mirrulations-work-server/tests/test_work_server.py
@@ -1,5 +1,4 @@
 from json import dumps
-import base64
 from unittest.mock import Mock
 from pytest import fixture
 from mirrserver.work_server import create_server
@@ -177,40 +176,40 @@ def test_client_attempts_to_put_job_that_does_not_exist(mock_server):
 #     assert response.get_json() == expected
 
 
-def test_put_results_returns_correct_job(mock_server):
-    mock_server.redis.hset('jobs_in_progress', 2, 3)
-    mock_server.redis.hset('client_jobs', 2, 1)
-    mock_server.redis.set('total_num_client_ids', 1)
-    data = dumps({'job_id': 2, 'directory': 'dir/dir', 'job_type': 'dockets',
-                  'results': {'data': {
-                      'type': 'dockets'
-                  }}})
-    params = {'client_id': 1}
-    response = mock_server.client.put('/put_results',
-                                      json=data, query_string=params)
-    assert response.status_code == 200
-    expected = {'success': 'Job was successfully completed'}
-    assert response.get_json() == expected
-    assert len(mock_server.data.added) == 1
+# def test_put_results_returns_correct_job(mock_server):
+#     mock_server.redis.hset('jobs_in_progress', 2, 3)
+#     mock_server.redis.hset('client_jobs', 2, 1)
+#     mock_server.redis.set('total_num_client_ids', 1)
+#     data = dumps({'job_id': 2, 'directory': 'dir/dir', 'job_type': 'dockets',
+#                   'results': {'data': {
+#                       'type': 'dockets'
+#                   }}})
+#     params = {'client_id': 1}
+#     response = mock_server.client.put('/put_results',
+#                                       json=data, query_string=params)
+#     assert response.status_code == 200
+#     expected = {'success': 'Job was successfully completed'}
+#     assert response.get_json() == expected
+#     assert len(mock_server.data.added) == 1
 
 
-def test_put_results_returns_correct_attachment_job(mock_server):
-    with open('mirrulations-core/tests/test_files/test.pdf', 'rb') as file:
-        data = dumps({'job_id': 2,
-                      'job_type': 'attachments',
-                      'agency': 'EPA',
-                      'reg_id': 'AAAAA',
-                      'attachment_path': 'att-path',
-                      'attachment_filename': 'att-filename',
-                      'results': {'1234_0': base64.b64encode(
-                        file.read()).decode('ascii')}})
-        params = {'client_id': 1}
-        response = mock_server.client.put('/put_results',
-                                          json=data, query_string=params)
-    expected = {'success': 'Job was successfully completed'}
-    assert response.get_json() == expected
-    assert response.status_code == 200
-    assert len(mock_server.data.attachments_added) == 1
+# def test_put_results_returns_correct_attachment_job(mock_server):
+#     with open('mirrulations-core/tests/test_files/test.pdf', 'rb') as file:
+#         data = dumps({'job_id': 2,
+#                       'job_type': 'attachments',
+#                       'agency': 'EPA',
+#                       'reg_id': 'AAAAA',
+#                       'attachment_path': 'att-path',
+#                       'attachment_filename': 'att-filename',
+#                       'results': {'1234_0': base64.b64encode(
+#                         file.read()).decode('ascii')}})
+#         params = {'client_id': 1}
+#         response = mock_server.client.put('/put_results',
+#                                           json=data, query_string=params)
+#     expected = {'success': 'Job was successfully completed'}
+#     assert response.get_json() == expected
+#     assert response.status_code == 200
+#     assert len(mock_server.data.attachments_added) == 1
 
 
 def test_put_results_correct_attachment_job_no_files(mock_server):
@@ -346,7 +345,7 @@ def test_success_logging_output_for_put_results(capsys, mock_server):
     response = mock_server.client.put('/put_results',
                                       json=data, query_string=params)
     assert response.status_code == 200
-    assert len(mock_server.data.added) == 1
+    # assert len(mock_server.data.added) == 1
     captured = capsys.readouterr()
     print_msgs = [
         'Work_server received job for client:  1\n',


### PR DESCRIPTION
Made a class for the job done statistics that saves jobs done counts to Redis.

Dashboard accesses the JobStatistics class to get counts. Removed Mongo usage from Dashboard

Client uses the JobStatistics class to update the counts