### PR TITLE
Generalize rabbitmq

### DIFF
--- a/mirrulations-core/src/mirrcore/job_queue.py
+++ b/mirrulations-core/src/mirrcore/job_queue.py
@@ -11,7 +11,7 @@ class JobQueue:
 
     def __init__(self, database):
         self.database = database
-        self.rabbitmq = RabbitMQ()
+        self.rabbitmq = RabbitMQ('jobs_waiting_queue')
 
         if not self.database.exists('num_jobs_comments_waiting'):
             self.database.set('num_jobs_comments_waiting', 0)

--- a/mirrulations-core/src/mirrcore/rabbitmq.py
+++ b/mirrulations-core/src/mirrcore/rabbitmq.py
@@ -70,10 +70,8 @@ class RabbitMQ:
         self._ensure_channel()
         try:
             get_channel = self.channel.basic_get(self.queue_name)
-            get_job_waiting_queue = get_channel
-            frames = get_job_waiting_queue
-            method_frame = frames[0]
-            body = frames[2]
+            method_frame = get_channel[0]
+            body = get_channel[2]
             # If there was no job available
             if method_frame is None:
                 return None

--- a/mirrulations-core/tests/test_rabbitmq.py
+++ b/mirrulations-core/tests/test_rabbitmq.py
@@ -56,7 +56,7 @@ def test_rabbit_interactions(monkeypatch):
 
     monkeypatch.setattr(pika, 'BlockingConnection', PikaSpy)
 
-    rabbit = RabbitMQ()
+    rabbit = RabbitMQ('jobs_waiting_queue')
     rabbit.add('foo')
     rabbit.size()
     rabbit.get()
@@ -65,7 +65,7 @@ def test_rabbit_interactions(monkeypatch):
 def test_rabbit_error_interactions(monkeypatch):
     monkeypatch.setattr(pika, 'BlockingConnection', BadPikaSpy)
 
-    rabbitmq = RabbitMQ()
+    rabbitmq = RabbitMQ('jobs_waiting_queue')
 
     # Ensure that the exception is raised when add() is called
     with pytest.raises(JobQueueException):


### PR DESCRIPTION
This PR refactors RabbitMQ and the files in which it is used to be more general. It was originally designed and hard-coded to work with the 'job_waiting_queue', but now, it should work with any queue we want.