### PR TITLE
add catch for TypeError when using high_level extract

### DIFF
--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -65,7 +65,7 @@ class Extractor:
             return
         try:
             text = pdfminer.high_level.extract_text(pdf_bytes)
-        except ValueError as err:
+        except (ValueError, TypeError) as err:
             print("FAILURE: failed to extract "
                   f"text from {attachment_path}\n{err}")
             return


### PR DESCRIPTION
Another fix for the text extraction due to unforeseen corrupt pdfs.