### PR TITLE
Remove pylint disable from extraction_queue.py

### DIFF
--- a/mirrulations-core/src/mirrcore/extraction_queue.py
+++ b/mirrulations-core/src/mirrcore/extraction_queue.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-arguments
 import os
 from mirrcore.rabbitmq import RabbitMQ
 


### PR DESCRIPTION
This disable is unneeded in the file. It seems like it can be removed. 