### PR TITLE
Corrects issue with saving full data dict to S3

### DIFF
--- a/mirrulations-client/src/mirrclient/saver.py
+++ b/mirrulations-client/src/mirrclient/saver.py
@@ -76,7 +76,7 @@ class Saver:
             s_3 = AmazonS3()
             s_3.put_text_s3(bucket,
                             path,
-                            data)
+                            data["results"])
             print(f"SUCCESS: Wrote json to S3: {path}")
         except NoCredentialsError as error:
             print(error)

--- a/mirrulations-client/tests/test_saver.py
+++ b/mirrulations-client/tests/test_saver.py
@@ -168,13 +168,12 @@ def test_save_valid_json_to_s3():
     saver = Saver()
     test_path = "testpath"
     test_json = {
-        "data": {"attributes": 0}
+        "results": "test"
     }
     saver.save_json_to_s3("test-mirrulations1", test_path, test_json)
     body = conn.Object("test-mirrulations1", "testpath").get()["Body"] \
-                                                        .read() \
-                                                        .decode("utf-8")
-    assert body == '{"data": {"attributes": 0}}'
+        .read().decode("utf-8").strip('/"')
+    assert body == test_json["results"]
 
 
 @mock_s3


### PR DESCRIPTION
* S3 was saving the full data dictionary, not just the JSON result
* This problem should be fixed when we do the next S3 sync
* data["results"] is the correct json result
* Just data includes keys "job_id", "job_type", "results"