### PR TITLE
Remove Mongo and Work_Server from javascript

### DIFF
--- a/mirrulations-dashboard/src/mirrdash/static/index.js
+++ b/mirrulations-dashboard/src/mirrdash/static/index.js
@@ -160,10 +160,8 @@ const updateDeveloperDashboardData = () => {
             client24,
             client25,
             nginx,
-            mongo,
             redis,
             work_generator,
-            work_server, 
             rabbitmq
         } = jobInformation;
 
@@ -193,10 +191,8 @@ const updateDeveloperDashboardData = () => {
         updateStatus('client24-status', client24)
         updateStatus('client25-status', client25)
         updateStatus('nginx-status', nginx)
-        updateStatus('mongo-status', mongo)
         updateStatus('redis-status', redis);
         updateStatus('work-generator-status', work_generator);
-        updateStatus('work-server-status', work_server);
         updateStatus('rabbitmq-status', rabbitmq);
     })
     .catch((err) => console.log(err));


### PR DESCRIPTION
The javascript file for the dashboard's front end was updated to remove Mongo and Work_server updateStatus() calls