### PR TITLE
Add extractor env file to dev script

### DIFF
--- a/dev_setup.py
+++ b/dev_setup.py
@@ -32,7 +32,6 @@ def write_files(api_key, env_path, total_clients, aws_access_key, aws_secret_acc
             file.write(f"AWS_ACCESS_KEY={aws_access_key}\n")
             file.write(f"AWS_SECRET_ACCESS_KEY={aws_secret_access_key}")
 
-
     # Write work generator file
     with open("{}work_gen.env".format(env_path), 'w') as file:
         file.write("API_KEY={}".format(api_key) + "\n")
@@ -43,6 +42,11 @@ def write_files(api_key, env_path, total_clients, aws_access_key, aws_secret_acc
         file.write("MONGO_HOSTNAME=mongo" + "\n")
         file.write("REDIS_HOSTNAME=redis" + "\n")
         file.write("PYTHONUNBUFFERED=TRUE")
+    
+    # Write extractor file
+    with open("{}extractor.env".format(env_path), 'w') as file:
+        file.write(f"AWS_ACCESS_KEY={aws_access_key}\n")
+        file.write(f"AWS_SECRET_ACCESS_KEY={aws_secret_access_key}")
     
     # Write validator file
     with open("{}validator.env".format(env_path), 'w') as file:


### PR DESCRIPTION
This will add the creation of the extractor.env file to the env_files folder in the dev setup script. This was necessary because running devup would not work because it would expect extractor.env if it wasn't manually created.