### PR TITLE
Redis counter only increases with new data

### DIFF
--- a/mirrulations-client/src/mirrclient/disk_saver.py
+++ b/mirrulations-client/src/mirrclient/disk_saver.py
@@ -4,6 +4,9 @@ from json import dumps, load
 
 class DiskSaver():
 
+    def __init__(self, increase_cache_callback=None) -> None:
+        self.increase_cache_var = increase_cache_callback
+
     def make_path(self, _dir):
         try:
             os.makedirs(_dir)
@@ -23,11 +26,14 @@ class DiskSaver():
         data : dict
             the results data to be written to disk
         """
+        results = data
         _dir = path.rsplit('/', 1)[0]
         self.make_path(_dir)
         data = data['results']
         if os.path.exists(path) is False:
             self.save_to_disk(path, data)
+            # cache should only increase with a completely new job
+            self.increase_cache_var(results)
         else:
             self.check_for_duplicates(path, data, 1)
 

--- a/mirrulations-client/tests/test_disk_saver.py
+++ b/mirrulations-client/tests/test_disk_saver.py
@@ -49,10 +49,11 @@ def test_save_path_directory_already_exists(capsys):
         assert captured.out == print_data
 
 
-def test_save_json():
+def test_save_json(mocker):
     saver = DiskSaver()
     path = '/USTR/file.json'
     data = {'results': 'Hello world'}
+    mocker.patch.object(saver, 'increase_cache_var', MagicMock())
     with patch('mirrclient.disk_saver.open', mock_open()) as mocked_file:
         with patch('os.makedirs') as mock_dir:
             saver.save_json(path, data)


### PR DESCRIPTION
attempt to fix redis counter going up when duplicate data comes through from regulations. Made a callback function in Client which gets passed onto DiskSaver. when disksaver finds the path for the job doesn't exist, calls the callback, increasing the redis counter.

Have to write code/test for the non-happy path