### PR TITLE
Data not found exception

### DIFF
--- a/mirrulations-core/src/mirrcore/data_counts.py
+++ b/mirrulations-core/src/mirrcore/data_counts.py
@@ -21,9 +21,9 @@ class DataCounts:
         Uses 3 API calls each time it is called.
         @return: list of counts for docket, document, and comments
         """
-        dockets = self._get_dockets_count()
-        documents = self._get_documents_count()
-        comments = self._get_comments_count()
+        dockets = self._get_data_count("dockets")
+        documents = self._get_data_count("documents")
+        comments = self._get_data_count("comments")
 
         for data in [dockets, documents, comments]:
             if not isinstance(data, int) or data < 0:
@@ -31,28 +31,13 @@ class DataCounts:
 
         return [dockets, documents, comments]
 
-    def _get_dockets_count(self):
+    def _get_data_count(self, endpoint):
         """
-        Get the number of docket entries on Regulations.gov
-        @return integer count of docket entries
+        Get the number of entries on Regulations.gov
+        @param endpoint: string "dockets", "documents", or "comments"
+        @return integer count of entries
         """
-        response = self.__make_api_call("dockets")
-        return self.__get_total_elements(response)
-
-    def _get_documents_count(self):
-        """
-        Get the number of document entries on Regulations.gov
-        @return integer count of document entries
-        """
-        response = self.__make_api_call("documents")
-        return self.__get_total_elements(response)
-
-    def _get_comments_count(self):
-        """
-        Get the number of comment entries on Regulations.gov
-        @return integer count of comment entries
-        """
-        response = self.__make_api_call("comments")
+        response = self.__make_api_call(endpoint)
         return self.__get_total_elements(response)
 
     def __get_total_elements(self, response):

--- a/mirrulations-core/src/mirrcore/data_counts.py
+++ b/mirrulations-core/src/mirrcore/data_counts.py
@@ -1,3 +1,4 @@
+import requests
 from mirrcore.regulations_api import RegulationsAPI
 
 
@@ -23,6 +24,11 @@ class DataCounts:
         dockets = self._get_dockets_count()
         documents = self._get_documents_count()
         comments = self._get_comments_count()
+
+        for data in [dockets, documents, comments]:
+            if not isinstance(data, int) or data < 0:
+                raise DataNotFoundException("Invalid data")
+
         return [dockets, documents, comments]
 
     def _get_dockets_count(self):
@@ -30,7 +36,7 @@ class DataCounts:
         Get the number of docket entries on Regulations.gov
         @return integer count of docket entries
         """
-        response = self.regulations_api.download(f'{self.url}/{"dockets"}')
+        response = self.__make_api_call("dockets")
         return self.__get_total_elements(response)
 
     def _get_documents_count(self):
@@ -38,7 +44,7 @@ class DataCounts:
         Get the number of document entries on Regulations.gov
         @return integer count of document entries
         """
-        response = self.regulations_api.download(f'{self.url}/{"documents"}')
+        response = self.__make_api_call("documents")
         return self.__get_total_elements(response)
 
     def _get_comments_count(self):
@@ -46,11 +52,35 @@ class DataCounts:
         Get the number of comment entries on Regulations.gov
         @return integer count of comment entries
         """
-        response = self.regulations_api.download(f'{self.url}/{"comments"}')
+        response = self.__make_api_call("comments")
         return self.__get_total_elements(response)
 
     def __get_total_elements(self, response):
         """
         Get the total number of elements from the response
+        @param response: json response from Regulations.gov
+        @return integer count of elements
         """
-        return response['meta']['totalElements']
+        try:
+            return response['meta']['totalElements']
+        except KeyError as exc:
+            raise DataNotFoundException("Improper JSON structure") from exc
+
+    def __make_api_call(self, endpoint):
+        """
+        Make an API call to Regulations.gov
+        @param endpoint: string "dockets", "documents", or "comments"
+        @return json response from Regulations.gov
+        """
+        try:
+            response = self.regulations_api.download(f'{self.url}/{endpoint}')
+        except requests.exceptions.RequestException as exc:
+            raise DataNotFoundException from exc
+        return response
+
+
+class DataNotFoundException(Exception):
+    """
+    Generalized exception raised when data is not what
+    is expected from Regulations.gov
+    """

--- a/mirrulations-core/src/mirrcore/data_counts.py
+++ b/mirrulations-core/src/mirrcore/data_counts.py
@@ -27,13 +27,13 @@ class DataCounts:
 
         for data in [dockets, documents, comments]:
             if not isinstance(data, int) or data < 0:
-                raise DataNotFoundException("Invalid data")
+                raise DataNotFoundException("Invalid data in response")
 
         return [dockets, documents, comments]
 
     def _get_data_count(self, endpoint):
         """
-        Get the number of entries on Regulations.gov
+        Get the number of entries on Regulations.govou
         @param endpoint: string "dockets", "documents", or "comments"
         @return integer count of entries
         """

--- a/mirrulations-work-generator/src/mirrgen/work_generator.py
+++ b/mirrulations-work-generator/src/mirrgen/work_generator.py
@@ -7,7 +7,7 @@ from mirrcore.regulations_api import RegulationsAPI
 from mirrcore.job_queue import JobQueue
 from mirrcore.job_queue_exceptions import JobQueueException
 from mirrcore.redis_check import load_redis
-from mirrcore.data_counts import DataCounts
+from mirrcore.data_counts import DataCounts, DataNotFoundException
 from mirrcore.jobs_statistics import JobStatistics
 
 
@@ -48,12 +48,7 @@ if __name__ == '__main__':
 
         generator = WorkGenerator(job_queue, api)
 
-        job_stats = JobStatistics(database)
-
-        # Save the total number of docket, document, and comment
-        # entries in Regulations.gov
-        regulations_data_counts = DataCounts(api_key).get_counts()
-        job_stats.set_regulations_data(regulations_data_counts)
+        update_data_counts(api_key, database)
 
         # Download dockets, documents, and comments
         # from all jobs in the job queue
@@ -66,6 +61,16 @@ if __name__ == '__main__':
         print('Begin generate comment jobs')
         generator.download('comments')
         print('End generate comment jobs')
+
+    def update_data_counts(api_key, database):
+        # Save the total number of docket, document, and comment
+        # entries in Regulations.gov
+        job_stats = JobStatistics(database)
+        try:
+            regulations_data_counts = DataCounts(api_key).get_counts()
+            job_stats.set_regulations_data(regulations_data_counts)
+        except DataNotFoundException:
+            print("Error occurred when getting data counts.")
 
     while True:
         try:


### PR DESCRIPTION
Handle exceptional cases when getting the data counts from Regulations.gov. 
DataCounts class raises a DataNotFoundException when Regulations.gov does not return the expected data. 
The work generator catches this exception and prints out a message.