### PR TITLE
handle struct.error exception

### DIFF
--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -2,11 +2,11 @@ from datetime import datetime
 import os
 import time
 import io
+import struct
 import pdfminer
 import pdfminer.high_level
 import pikepdf
 import redis
-import struct
 from mirrcore.path_generator import PathGenerator
 from mirrcore.jobs_statistics import JobStatistics
 from mirrclient.saver import Saver

--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -6,6 +6,7 @@ import pdfminer
 import pdfminer.high_level
 import pikepdf
 import redis
+import struct
 from mirrcore.path_generator import PathGenerator
 from mirrcore.jobs_statistics import JobStatistics
 from mirrclient.saver import Saver
@@ -80,7 +81,7 @@ class Extractor:
             return
         try:
             text = pdfminer.high_level.extract_text(pdf_bytes)
-        except (ValueError, TypeError) as err:
+        except (ValueError, TypeError, struct.error) as err:
             print("FAILURE: failed to extract "
                   f"text from {attachment_path}\n{err}")
             return

--- a/mirrulations-extractor/tests/test_extractor.py
+++ b/mirrulations-extractor/tests/test_extractor.py
@@ -1,9 +1,9 @@
+import struct
 from mirrextractor.extractor import Extractor
 from mirrmock.mock_redis import MockRedisWithStorage
 from mirrcore.jobs_statistics import JobStatistics
 import pikepdf
 import redis
-import struct
 import boto3
 from moto import mock_s3
 

--- a/mirrulations-extractor/tests/test_extractor.py
+++ b/mirrulations-extractor/tests/test_extractor.py
@@ -3,6 +3,7 @@ from mirrmock.mock_redis import MockRedisWithStorage
 from mirrcore.jobs_statistics import JobStatistics
 import pikepdf
 import redis
+import struct
 import boto3
 from moto import mock_s3
 
@@ -26,6 +27,13 @@ def test_extract_text_non_pdf(capfd, mocker):
     Extractor.extract_text('a.docx', 'b.txt')
     assert "FAILURE: attachment doesn't have appropriate extension a.docx" \
         in capfd.readouterr()[0]
+
+
+def test_extract_raises_struct_error(mocker, capfd):
+    mocker.patch('pdfminer.high_level.extract_text', side_effect=struct.error)
+    mocker.patch('pikepdf.open', return_value=pikepdf.Pdf.new())
+    Extractor.extract_text('a.pdf', 'b.txt')
+    assert "FAILURE: failed to extract" in capfd.readouterr()[0]
 
 
 def test_open_pdf_throws_pikepdf_error(mocker, capfd):


### PR DESCRIPTION

Some pdfs are generating a struct.error when extracting text.  This fix catches the error, logs it, and then moves on.

