### PR TITLE
add env file and remove restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-    restart: always
+    env_file: env_files/extractor.env
     volumes:
       - "~/data/data:/data"
   dashboard:


### PR DESCRIPTION
Add the env file that contains the AWS credentials.

Also, remove restart for now.  If the extractor fails on a pdf file it will try the same pdf after restart and fail again.  This will likely cause a resource leak over time.

