### PR TITLE
Handle password on pdf

### DIFF
--- a/mirrulations-extractor/src/mirrextractor/extractor.py
+++ b/mirrulations-extractor/src/mirrextractor/extractor.py
@@ -70,7 +70,7 @@ class Extractor:
         """
         try:
             pdf = pikepdf.open(attachment_path)
-        except pikepdf.PdfError as err:
+        except (pikepdf.PdfError, pikepdf.PasswordError) as err:
             print(f"FAILURE: failed to open {attachment_path}\n{err}")
             return
         pdf_bytes = io.BytesIO()

--- a/mirrulations-extractor/tests/test_extractor.py
+++ b/mirrulations-extractor/tests/test_extractor.py
@@ -29,6 +29,12 @@ def test_extract_text_non_pdf(capfd, mocker):
         in capfd.readouterr()[0]
 
 
+def test_extract_raises_password_error(mocker, capfd):
+    mocker.patch('pikepdf.open', side_effect=pikepdf.PasswordError)
+    Extractor.extract_text('a.pdf', 'b.txt')
+    assert "FAILURE: failed to open" in capfd.readouterr()[0]
+
+
 def test_extract_raises_struct_error(mocker, capfd):
     mocker.patch('pdfminer.high_level.extract_text', side_effect=struct.error)
     mocker.patch('pikepdf.open', return_value=pikepdf.Pdf.new())


### PR DESCRIPTION
If a file contains a password, we skip it.

For future reference, this is an example of a file with a password: `/data/data/AMS/AMS-SC-19-0042/binary-AMS-SC-19-0042/comments_attachments/AMS-SC-19-0042-1782_attachment_1.pdf` 