### PR TITLE
Change logging on all containers to "local."

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       - "80:80"
     depends_on:
       - dashboard
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   redis:
     image: redis:6.2.4
     volumes:
@@ -16,10 +20,14 @@ services:
       - "6379:6379"
     restart: always
     healthcheck:
-      test: [ "CMD", "redis-cli","ping" ]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 10s
       retries: 5
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   rabbitmq:
     build:
       context: .
@@ -35,6 +43,10 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   work_generator:
     build:
       context: .
@@ -46,6 +58,10 @@ services:
         condition: service_healthy
     env_file: env_files/work_gen.env
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   validator:
     build:
       context: .
@@ -60,6 +76,10 @@ services:
     volumes:
       - "~/data/validator:/data/validator"
       - "~/data/data:/data/data"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   extractor:
     build:
       context: .
@@ -70,6 +90,10 @@ services:
     env_file: env_files/extractor.env
     volumes:
       - "~/data/data:/data"
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   dashboard:
     build:
       context: .
@@ -82,6 +106,10 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client1:
     build:
       context: .
@@ -90,6 +118,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client2:
     build:
       context: .
@@ -98,6 +130,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client3:
     build:
       context: .
@@ -106,6 +142,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client4:
     build:
       context: .
@@ -114,6 +154,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client5:
     build:
       context: .
@@ -122,6 +166,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client6:
     build:
       context: .
@@ -130,6 +178,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client7:
     build:
       context: .
@@ -138,6 +190,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client8:
     build:
       context: .
@@ -146,6 +202,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client9:
     build:
       context: .
@@ -154,6 +214,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client10:
     build:
       context: .
@@ -162,6 +226,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client11:
     build:
       context: .
@@ -170,6 +238,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client12:
     build:
       context: .
@@ -178,6 +250,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client13:
     build:
       context: .
@@ -186,6 +262,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client14:
     build:
       context: .
@@ -194,6 +274,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client15:
     build:
       context: .
@@ -202,6 +286,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client16:
     build:
       context: .
@@ -210,6 +298,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client17:
     build:
       context: .
@@ -218,6 +310,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client18:
     build:
       context: .
@@ -226,6 +322,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client19:
     build:
       context: .
@@ -234,6 +334,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client20:
     build:
       context: .
@@ -242,6 +346,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client21:
     build:
       context: .
@@ -250,6 +358,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client22:
     build:
       context: .
@@ -258,6 +370,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client23:
     build:
       context: .
@@ -266,6 +382,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client24:
     build:
       context: .
@@ -274,6 +394,10 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
   client25:
     build:
       context: .
@@ -282,3 +406,7 @@ services:
     volumes:
       - ~/data/data:/data
     restart: always
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"


### PR DESCRIPTION
Log file size is unbounded by default, and we log a lot of stuff. The "local" setting for logs uses a max file size for the log file, which will limit how much disk space is used by our logs.

All containers are set to use a 10MB log, which should give us plenty of historical data to see what is happening.