### PR TITLE
More Informative Dashboard Container Status

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -11,3 +11,78 @@ The `/` endpoint will return an HTML/CSS display of the information on the jobs.
 The dashboard itself will show the number of jobs in the queue, the number of jobs in the queue of each type, the number of jobs in progress, and the number of completed jobs. It will also display the percentage of each category as well. Finally, the dashboard also displays each container currently running on the system, along with information describing its current status. This front-end will be made of HTML, CSS, and Javascript.
 
 Currently, the server runs through port `5000`. Down the line, we hope to run through HTTPS. 
+
+## API
+
+For the examples below substitute `<dashboard>` with your dashboard url.
+On development environments this defaults to `http://localhost`.
+
+### Job Status
+
+```
+GET <dashboard>/data
+```
+
+Provides the counts and progress for various jobs in the json format below.
+
+Here is the body of a sample response
+
+```json
+{
+  "jobs_total": 115750,
+  "mirrulations_bucket_size": 0,
+  "num_attachments_done": 0,
+  "num_comments_done": 0,
+  "num_dockets_done": 7,
+  "num_documents_done": 0,
+  "num_extractions_done": 0,
+  "num_jobs_comments_queued": 0,
+  "num_jobs_dockets_queued": 115743,
+  "num_jobs_documents_queued": 0,
+  "num_jobs_done": 7,
+  "num_jobs_in_progress": 0,
+  "num_jobs_waiting": 115743,
+  "num_pdf_attachments_done": 0,
+  "regulations_total_comments": 22075373,
+  "regulations_total_dockets": 253566,
+  "regulations_total_documents": 1842126
+}
+```
+
+### System Status
+
+```
+GET <dashboard>/devdata
+```
+
+Provides the status of currently created containers.
+If a container has a health check its current health is also returned.
+
+Here is the body of a sample response
+```json
+{
+  "client1": {
+    "status": "paused"
+  },
+  "dashboard": {
+    "status": "running"
+  },
+  "extractor": {
+    "status": "exited"
+  },
+  "nginx": {
+    "status": "running"
+  },
+  "rabbitmq": {
+    "health": "healthy",
+    "status": "running"
+  },
+  "redis": {
+    "health": "healthy",
+    "status": "running"
+  },
+  "work_generator": {
+    "status": "paused"
+  }
+}
+```

--- a/mirrulations-dashboard/src/mirrdash/dashboard_server.py
+++ b/mirrulations-dashboard/src/mirrdash/dashboard_server.py
@@ -34,10 +34,12 @@ def get_jobs_stats(job_queue):
 
 def get_container_stats(client):
     stats = {}
-    for container in client.containers.list():
+    for container in client.containers.list(all=True):
         name = get_container_name(container.name)
-        status = container.status
-        stats[name] = status
+        state = {'status': container.status}
+        if container.health != 'unknown':
+            state['health'] = container.health
+        stats[name] = state
     return stats
 
 

--- a/mirrulations-dashboard/src/mirrdash/static/index.js
+++ b/mirrulations-dashboard/src/mirrdash/static/index.js
@@ -72,17 +72,29 @@ const updateHtmlValues = (jobsWaiting, jobsDone, pdfAttachments, pdfExtracted) =
     }
 }
 
-const updateStatus = (container, status) => {
+const updateStatus = (container, state) => {
         let status_span = document.getElementById(container)
-        if (status == "running") {
-            status_span.textContent = "RUNNING";
-            status_span.style.color = "green";
-        }
-        else {
-            status_span.textContent = 'ERROR';
-            status_span.style.color = "red";
-        }
+        let text = "NOT RUNNING";
+        let color = "grey";
 
+
+        if (state) {
+        switch(state.status) {
+            case "running":
+                text = "RUNNING";
+                color = "green";
+                break;
+            case "exited":
+                text = "EXITED";
+                color = "red";
+                break;
+            default:
+                text = state.status.toUpperCase();
+                color = "orange";
+        }}
+
+        status_span.textContent = text;
+        status_span.style.color = color;
 }
 
 const updateJobTypeProgress = (id, value, total) => {

--- a/mirrulations-dashboard/tests/test_dashboard.py
+++ b/mirrulations-dashboard/tests/test_dashboard.py
@@ -83,16 +83,22 @@ def test_dev_dashboard_returns_container_information(mock_server):
 
     # Mock out the docker object to return Container-like values
     # for the list method.
-    Container = namedtuple('Container', ['name', 'status'])
-    return_value = [Container('capstone_client1_1', 'running'),
-                    Container('capstone_work_server_1', 'running')]
+    Container = namedtuple('Container', ['name', 'status', 'health'])
+    return_value = [
+        Container(name="capstone_client1_1", status="running", health="unknown"),
+        Container(name="capstone_work_server_1", status="paused", health="unknown"),
+        Container(name="capstone_redis_1", status="running", health="healthy"),
+    ]
     client.containers.list = Mock(return_value=return_value)
 
     mock_server.docker = client
     response = mock_server.client.get('/devdata')
 
-    expected = {'client1': 'running',
-                'work_server': 'running'}
+    expected = {
+        "client1": {"status": "running"},
+        "work_server": {"status": "paused"},
+        "redis": {"status": "running", "health": "healthy"},
+    }
 
     assert response.status_code == 200
     results = response.get_json()
@@ -122,15 +128,21 @@ def test_get_container_stats():
 
     # Mock out the docker object to return Container-like values
     # for the list method.
-    Container = namedtuple('Container', ['name', 'status'])
-    return_value = [Container('capstone_client1_1', 'running'),
-                    Container('capstone_work_server_1', 'running')]
+    Container = namedtuple('Container', ['name', 'status','health'])
+    return_value = [
+        Container(name="capstone_client1_1", status="running", health="unknown"),
+        Container(name="capstone_work_server_1", status="paused", health="unknown"),
+        Container(name="capstone_redis_1", status="running", health="healthy"),
+    ]
     client.containers.list = Mock(return_value=return_value)
 
     stats = get_container_stats(client)
 
-    expected = {'client1': 'running',
-                'work_server': 'running'}
+    expected = {
+        "client1": {"status": "running"},
+        "work_server": {"status": "paused"},
+        "redis": {"status": "running", "health": "healthy"},
+    }
 
     assert stats == expected
 

--- a/mirrulations-dashboard/tests/test_dashboard.py
+++ b/mirrulations-dashboard/tests/test_dashboard.py
@@ -83,11 +83,17 @@ def test_dev_dashboard_returns_container_information(mock_server):
 
     # Mock out the docker object to return Container-like values
     # for the list method.
-    Container = namedtuple('Container', ['name', 'status', 'health'])
+    Container = namedtuple("Container", ["name", "status", "health"])
     return_value = [
-        Container(name="capstone_client1_1", status="running", health="unknown"),
-        Container(name="capstone_work_server_1", status="paused", health="unknown"),
-        Container(name="capstone_redis_1", status="running", health="healthy"),
+        Container(name="capstone_client1_1",
+                  status="running",
+                  health="unknown"),
+        Container(name="capstone_work_server_1",
+                  status="paused",
+                  health="unknown"),
+        Container(name="capstone_redis_1",
+                  status="running",
+                  health="healthy"),
     ]
     client.containers.list = Mock(return_value=return_value)
 
@@ -128,11 +134,17 @@ def test_get_container_stats():
 
     # Mock out the docker object to return Container-like values
     # for the list method.
-    Container = namedtuple('Container', ['name', 'status','health'])
+    Container = namedtuple('Container', ['name', 'status', 'health'])
     return_value = [
-        Container(name="capstone_client1_1", status="running", health="unknown"),
-        Container(name="capstone_work_server_1", status="paused", health="unknown"),
-        Container(name="capstone_redis_1", status="running", health="healthy"),
+        Container(name="capstone_client1_1",
+                  status="running",
+                  health="unknown"),
+        Container(name="capstone_work_server_1",
+                  status="paused",
+                  health="unknown"),
+        Container(name="capstone_redis_1",
+                  status="running",
+                  health="healthy"),
     ]
     client.containers.list = Mock(return_value=return_value)
 


### PR DESCRIPTION
This PR contains makes the dashboard better reflect the true status of a container. It also better documents the dashboard API by providing examples.

#### Summary

* return the actual container state according to docker
* style running and not running container cards differently
* update documentation/tests