### PR TITLE
Fix computation of bucket size

### DIFF
--- a/mirrulations-core/src/mirrcore/bucket_size.py
+++ b/mirrulations-core/src/mirrcore/bucket_size.py
@@ -4,9 +4,6 @@ import math
 import boto3
 from dotenv import load_dotenv
 
-end_time = datetime.now(UTC)
-start_time = end_time - timedelta(days=2)
-
 
 class BucketSize:
     """
@@ -22,30 +19,59 @@ class BucketSize:
 
     @staticmethod
     def get_bucket_size():
-        """Returns the size of the bucket in gigabytes"""
+        """Returns the size of the bucket in binary gigabytes (1024³ bytes).
+
+        S3 publishes ``BucketSizeBytes`` per ``StorageType`` (Standard,
+        Intelligent-Tiering tiers, Glacier, etc.). Total size is the sum of
+        the latest daily observation for each distinct series—not the sum of
+        ``Datapoints`` across time for one series.
+        """
         client = BucketSize.get_cloudwatch_client()
         # when client cannot establish connection to cloudwatch due to no AWS
         # credentials, return
         if not client:
             return None
+        total_bytes = 0.0
+        paginator = client.get_paginator("list_metrics")
+        for page in paginator.paginate(
+            Namespace="AWS/S3",
+            MetricName="BucketSizeBytes",
+            Dimensions=[{"Name": "BucketName", "Value": "mirrulations"}],
+        ):
+            for metric in page.get("Metrics", []):
+                total_bytes += BucketSize._bytes_for_metric_series(
+                    client, metric
+                )
+
+        bytes_per_gb = 1 << 30  # GiB-style GB: 1024³
+        bucket_size_gb = math.ceil(total_bytes / bytes_per_gb)
+        return bucket_size_gb
+
+    @staticmethod
+    def _bytes_for_metric_series(client, metric):
+        dimensions = metric.get("Dimensions", [])
+        stor_type = None
+        for dim in dimensions:
+            if dim.get("Name") == "StorageType":
+                stor_type = dim.get("Value")
+                break
+        if stor_type is None:
+            return 0.0
         result = client.get_metric_statistics(
             Namespace="AWS/S3",
-            Dimensions=[{"Name": "BucketName", "Value": "mirrulations"},
-                        {"Name": "StorageType", "Value": "StandardStorage"}],
+            Dimensions=dimensions,
             MetricName="BucketSizeBytes",
-            StartTime=start_time,
+            StartTime=datetime.now(UTC) - timedelta(days=2),
             EndTime=datetime.now(UTC),
             Period=86400,  # 1 day in seconds
-            Statistics=['Average'],
-            Unit='Bytes'
+            Statistics=["Average"],
+            Unit="Bytes",
         )
-        # Extract the bucket size from the client metric data
-        bucket_size_bytes = result['Datapoints'][0]["Average"]
-
-        # Convert the size from bytes to GB
-        bucket_size_gb = math.ceil(bucket_size_bytes / (1000 ** 3))
-
-        return bucket_size_gb
+        datapoints = result.get("Datapoints", [])
+        if not datapoints:
+            return 0.0
+        latest = max(datapoints, key=lambda p: p["Timestamp"])
+        return float(latest["Average"])
 
     @staticmethod
     def get_cloudwatch_client():

--- a/mirrulations-core/tests/test_bucket_size.py
+++ b/mirrulations-core/tests/test_bucket_size.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
-from datetime import UTC
+from datetime import UTC, datetime
 import os
-import math
 from mirrcore.bucket_size import BucketSize
 from pytest import fixture
 from botocore.client import BaseClient
@@ -47,21 +46,54 @@ def test_get_bucket_size(mock_method):
     """
     needed the patch for mocking the return value of a static function
 
-    Mocks the process of getting the size of a bucket with the
-    get_metric_statistics function of a cloudwatch client
+    BucketSizeBytes exists per StorageType; get_bucket_size lists metrics
+    and sums the latest daily Average for each series.
     """
-    # Mock the CloudWatch client
     client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {
+            'Metrics': [
+                {
+                    'Namespace': 'AWS/S3',
+                    'MetricName': 'BucketSizeBytes',
+                    'Dimensions': [
+                        {'Name': 'BucketName', 'Value': 'mirrulations'},
+                        {'Name': 'StorageType', 'Value': 'StandardStorage'},
+                    ],
+                },
+                {
+                    'Namespace': 'AWS/S3',
+                    'MetricName': 'BucketSizeBytes',
+                    'Dimensions': [
+                        {'Name': 'BucketName', 'Value': 'mirrulations'},
+                        {'Name': 'StorageType',
+                         'Value': 'IntelligentTieringIAStorage'},
+                    ],
+                },
+            ]
+        },
+    ]
+    client.get_paginator.return_value = paginator
+
+    # Bucket total: 1500.5 GiB (1024³, same divisor as BucketSize).
+    # Two StorageTypes each contribute half of that total bytes.
+    bytes_per_gib = 1 << 30
+    total_bucket_bytes = int(1500.5 * bytes_per_gib)
+    bytes_per_storage_type = total_bucket_bytes // 2
+
+    ts = datetime(2026, 5, 6, tzinfo=UTC)
 
     client.get_metric_statistics.return_value = {
-        'Datapoints': [{'Average': 12345678910}]
+        'Datapoints': [{'Timestamp': ts, 'Average': bytes_per_storage_type}],
     }
 
     mock_method.return_value = client
 
-    result = math.ceil(BucketSize.get_bucket_size())
-
-    assert result == 13  # Expected result in GB
-    call_kwargs = client.get_metric_statistics.call_args.kwargs
-    assert call_kwargs["StartTime"].tzinfo is UTC
-    assert call_kwargs["EndTime"].tzinfo is UTC
+    # math.ceil(1500.5 binary GB) == 1501
+    assert BucketSize.get_bucket_size() == 1501
+    client.get_paginator.assert_called_once_with('list_metrics')
+    kwargs0 = client.get_metric_statistics.call_args_list[0].kwargs
+    assert kwargs0["StartTime"].tzinfo is UTC
+    assert kwargs0["EndTime"].tzinfo is UTC
+    assert len(client.get_metric_statistics.call_args_list) == 2


### PR DESCRIPTION

To compute the bucket size you have to iterate over all the different storage types.  The mirrulations bucket is configured to move data into less expensive buckets if it is not accessed for a period of time.