### PR TITLE
Remove job_in_progress, client_jobs, and invalid_jobs and all referen…

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -25,7 +25,7 @@ If no work is available at the current time the client waits for 3.6 seconds bef
 
 After receiving a job, a client attempts to download the remote resource pointed to by its url. If the `job_type` is a comment, any attachments are also downloaded. The client updates the database after the job is completed.
 
-If an unrecoverable error occurs while during download, the client marks the job as an invalid job in the database. Invalid jobs will not be retried by other clients.
+If an unrecoverable error occurs during download, the client prints the failing job id and URL to the log, then continues. Those jobs are not retried automatically by other clients.
 
 ### Saving Data
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -8,7 +8,7 @@ The `data` endpoint will return JSON with the necessary information related to t
 
 The `/` endpoint will return an HTML/CSS display of the information on the jobs.
 
-The dashboard itself will show the number of jobs in the queue, the number of jobs in the queue of each type, the number of jobs in progress, and the number of completed jobs. It will also display the percentage of each category as well. Finally, the dashboard also displays each container currently running on the system, along with information describing its current status. This front-end will be made of HTML, CSS, and Javascript.
+The dashboard itself will show the number of jobs in the queue, the number of jobs in the queue of each type, and the number of completed jobs. It will also display the percentage of each category as well. Finally, the dashboard also displays each container currently running on the system, along with information describing its current status. This front-end will be made of HTML, CSS, and Javascript.
 
 Currently, the server runs through port `5000`. Down the line, we hope to run through HTTPS. 
 
@@ -29,7 +29,6 @@ Here is the body of a sample response
 
 ```json
 {
-  "jobs_total": 115750,
   "mirrulations_bucket_size": 0,
   "num_attachments_done": 0,
   "num_comments_done": 0,
@@ -39,7 +38,6 @@ Here is the body of a sample response
   "num_jobs_dockets_queued": 115743,
   "num_jobs_documents_queued": 0,
   "num_jobs_done": 7,
-  "num_jobs_in_progress": 0,
   "num_jobs_waiting": 115743,
   "num_pdf_attachments_done": 0,
   "regulations_total_comments": 22075373,

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,7 +18,6 @@ num_pdf_attachments_done
 num_jobs_documents_waiting
 num_jobs_comments_waiting
 dockets_last_timestamp
-invalid_jobs
 regulations_total_dockets
 client_jobs
 regulations_total_documents

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -98,10 +98,6 @@ class Client:
         self._set_default_key(job, 'agency', 'other_agency')
         return job
 
-    def _set_redis_values(self, job):
-        self.redis.hset('jobs_in_progress', job['job_id'], job['url'])
-        self.redis.hset('client_jobs', job['job_id'], self.client_id)
-
     def _remove_plural_from_job_type(self, job):
         split_url = str(job['url']).split('/')
         job_type = split_url[-2][:-1]  # Removes plural from job type
@@ -121,8 +117,6 @@ class Client:
         job = self._get_job_from_job_queue()
 
         job = self._set_missing_job_key_defaults(job)
-
-        self._set_redis_values(job)
 
         # update count for dashboard
         self.job_queue.decrement_count(job['job_type'])
@@ -338,10 +332,6 @@ class Client:
             return False
         return True
 
-    def _report_bad_job(self, job):
-        self.redis.hdel('jobs_in_progress', job['job_id'])
-        self.redis.hset('invalid_jobs', job['job_id'], job['url'])
-
     def job_operation(self):
         """
         Processes a job.
@@ -360,14 +350,11 @@ class Client:
             result = response.json()
 
             self._download_job(job, result)
-        except Exception as exc:
-            try:
-                self._report_bad_job(job)
-            except redis.exceptions.ConnectionError:
-                print("FAILURE: Couldn't save bad job to Redis.")
-
-            # re-raise whatever exception was being thrown
-            raise exc
+        except Exception:
+            print(
+                f'FAILURE: bad job job_id={job["job_id"]} url={job["url"]}',
+                flush=True)
+            raise
 
         return job
 

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -156,18 +156,6 @@ def test_get_job():
     assert client._get_job() == job
 
 
-def test_client_hsets_redis_values():
-    mock_redis = ReadyRedis()
-    client = Client(mock_redis, MockJobQueue())
-    mock_redis.set('jobs_in_progress', ['foo', 'var'])
-    mock_redis.set('client_jobs', ['foo', 'bar'])
-    job = {'job_id': 1,
-           'url': 'fake.com'}
-    client._set_redis_values(job)
-    assert mock_redis.get('jobs_in_progress') == [1, 'fake.com']
-    assert mock_redis.get('client_jobs') == [1, '-1']
-
-
 # Document HTM Tests
 def test_document_has_file_formats_does_not_have_data():
     client = Client(ReadyRedis(), MockJobQueue())
@@ -233,7 +221,6 @@ def test_client_downloads_document_htm(capsys, mocker):
     client.job_queue.add_job({'job_id': 1,
                               'url': 'http://regulations.gov/documents',
                               "job_type": "documents"})
-    mock_redis.set('jobs_in_progress', [1, 'http://regulations.gov/documents'])
 
     test_json = {'data': {'id': '1', 'type': 'documents',
                                 'attributes':
@@ -298,8 +285,6 @@ def test_handles_none_in_comment_file_formats(path_generator):
     client.job_queue.add_job({'job_id': 1,
                               'url': 'http://regulations.gov/job',
                               "job_type": "comments"})
-    mock_redis.set('jobs_in_progress', [1,
-                                        'http://regulations.gov/job'])
     test_json = {
                 "data": {
                     "id": "agencyID-001-0002",
@@ -317,9 +302,6 @@ def test_handles_none_in_comment_file_formats(path_generator):
     responses.add(responses.GET, 'http://regulations.gov/job',
                   json=test_json, status=200)
     client.job_operation()
-    assert mock_redis.get('jobs_in_progress') == [1,
-                                                  'http://regulations.gov/job']
-    assert mock_redis.get('client_jobs') == [1, '-1']
 
     attachment_paths = path_generator.get_attachment_json_paths(test_json)
     assert attachment_paths == []
@@ -337,7 +319,6 @@ def test_client_downloads_attachment_results(mocker, capsys):
     client.job_queue.add_job({'job_id': 1,
                               'url': 'http://regulations.gov/comments',
                               "job_type": "comments"})
-    mock_redis.set('jobs_in_progress', [1, 'http://regulations.gov/comments'])
 
     test_json = {
                 "data": {
@@ -481,14 +462,13 @@ def test_client_perform_job_times_out(mock_requests):
 
 
 @responses.activate
-def test_client_handles_api_timeout():
+def test_client_handles_api_timeout(capsys):
     mock_redis = ReadyRedis()
     client = Client(mock_redis, MockJobQueue())
     client.api_key = 1234
     client.job_queue.add_job({'job_id': 1,
                               'url': 'http://regulations.gov/job',
                               "job_type": "comments"})
-    mock_redis.set('jobs_in_progress', [1, 'http://regulations.gov/job'])
 
     responses.get("http://regulations.gov/job",
                   body=ReadTimeout("Read Timeout"))
@@ -496,7 +476,9 @@ def test_client_handles_api_timeout():
     with pytest.raises(APITimeoutException):
         client.job_operation()
 
-    assert mock_redis.get('invalid_jobs') == [1, 'http://regulations.gov/job']
+    captured = capsys.readouterr()
+    assert 'job_id=1' in captured.out
+    assert 'http://regulations.gov/job' in captured.out
 
 
 # Document HTML Tests
@@ -536,7 +518,6 @@ def test_client_downloads_document_html(capsys, mocker):
     client.job_queue.add_job({'job_id': 1,
                               'url': 'http://regulations.gov/documents',
                               "job_type": "documents"})
-    mock_redis.set('jobs_in_progress', [1, 'http://regulations.gov/documents'])
 
     test_json = {'data': {'id': '1', 'type': 'documents',
                                 'attributes':

--- a/mirrulations-core/src/mirrcore/job_queue.py
+++ b/mirrulations-core/src/mirrcore/job_queue.py
@@ -42,14 +42,9 @@ class JobQueue:
 
     def get_job_stats(self):
         jobs_waiting = self.get_num_jobs()
-        jobs_in_progress = int(self.database.hlen('jobs_in_progress'))
-        jobs_total_minus_jobs_done = jobs_waiting + jobs_in_progress
 
         return {
             'num_jobs_waiting': jobs_waiting,
-            'num_jobs_in_progress':
-                int(self.database.hlen('jobs_in_progress')),
-            'jobs_total': jobs_total_minus_jobs_done,
             'num_jobs_comments_queued':
                 int(self.database.get('num_jobs_comments_waiting')),
             'num_jobs_documents_queued':

--- a/mirrulations-dashboard/src/mirrdash/dashboard_server.py
+++ b/mirrulations-dashboard/src/mirrdash/dashboard_server.py
@@ -84,8 +84,6 @@ def create_server(job_queue, docker_server, cache):
 
             data.update(**jobs_done_info, **regulations_jobs_info)
 
-            # Add this value to the total jobs
-            data['jobs_total'] += jobs_done_info['num_jobs_done']
             # add bucket size to data
             data['mirrulations_bucket_size'] = bucket_size
         except (JobQueueException, redis.ConnectionError) as error:

--- a/mirrulations-dashboard/tests/test_dashboard.py
+++ b/mirrulations-dashboard/tests/test_dashboard.py
@@ -29,12 +29,6 @@ def fixture_mock_server():
 def add_mock_data_to_database(job_queue, job_stats=MockJobStatistics()):
     for job in range(1, 6):
         job_queue.add_job(f'http://requlations.gov/job{job}')
-    jobs_in_progress = {i: i for i in range(6, 10)}
-    # Reach into the Redis DB and set some values.  UGH
-    job_queue.database.hset('jobs_in_progress', mapping=jobs_in_progress)
-    jobs_done = {i: i for i in range(10, 13)}
-    job_queue.database.hset('jobs_done', mapping=jobs_done)
-    job_queue.database.set('total_num_client_ids', 2)
     job_queue.database.set('num_jobs_comments_waiting', 2)
     job_queue.database.set('num_jobs_documents_waiting', 2)
     job_queue.database.set('num_jobs_dockets_waiting', 1)
@@ -66,9 +60,7 @@ def test_dashboard_returns_job_information(mock_server):
     assert response.status_code == 200
     results = response.get_json()
     assert results['num_jobs_waiting'] == 5
-    assert results['num_jobs_in_progress'] == 4
     assert results['num_jobs_done'] == 7
-    assert results['jobs_total'] == 16
     assert results['num_jobs_comments_queued'] == 2
     assert results['num_jobs_documents_queued'] == 2
     assert results['num_jobs_dockets_queued'] == 1


### PR DESCRIPTION
…ces in the client and dashboard.

The client was adding to jobs_in_progress and client_jobs but never removing anything.  The dashboard was using the values to compute values that were never used in the UI.  This cleanup removes all of those, and removing them from the prod redis instance will save memory.

invalid_jobs was being written to by the client, but never used anywhere else.  I replaced the write to redis with a log message.