### PR TITLE
Make S3 write configurable.

### DIFF
--- a/docs/env_files.md
+++ b/docs/env_files.md
@@ -6,6 +6,8 @@ The `env_files/` directory holds secrets and local configuration for Docker Comp
 
 The download **client** container loads AWS credentials from `client.env` and loads one or more Regulations.gov API keys from **`client_keys.json`** (JSON array of `{"id": "...", "api_key": "..."}` objects). Set **`CLIENT_KEYS_PATH`** in `client.env` to the path where **`client_keys.json`** is mounted inside the container (see `docker-compose.yml`; the default layout uses `/config/client_keys.json`).
 
+**`S3_BUCKET`** controls S3 uploads: omit it or leave it unset to use the default bucket name `mirrulations`; set it to a non-empty string to use that bucket; set it to an empty value (`S3_BUCKET=` with nothing after `=`) or whitespace-only to disable S3 and write only to disk.
+
 `PYTHONUNBUFFERED=TRUE` keeps Python logging unbuffered for Docker logs.
 
 ## Work generator (`work_gen.env`)

--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -6,7 +6,7 @@ import redis
 from dotenv import load_dotenv
 from mirrclient.saver import Saver
 from mirrclient.disk_saver import DiskSaver
-from mirrclient.s3_saver import S3Saver
+from mirrclient.s3_saver import S3Saver, S3SaveError
 from mirrclient.exceptions import NoJobsAvailableException, APITimeoutException
 from mirrclient.key_manager import (
     KeyCredential,
@@ -20,6 +20,28 @@ from mirrcore.job_queue import JobQueue
 from mirrcore.jobs_statistics import JobStatistics
 from mirrcore.job_queue_exceptions import JobQueueException
 from pika.exceptions import AMQPConnectionError
+
+
+def _build_savers():
+    """
+    Disk is always enabled.
+
+    S3 is controlled by ``S3_BUCKET``:
+
+    * unset — use bucket name ``mirrulations`` (backward compatible default)
+    * empty or whitespace-only — disable S3 (disk only)
+    * any other value — use that string as the bucket name
+
+    Returns
+    -------
+    list
+        ``DiskSaver`` and optionally ``S3Saver``.
+    """
+    raw = os.getenv('S3_BUCKET')
+    if raw is not None and not raw.strip():
+        return [DiskSaver()]
+    bucket = (raw.strip() if raw else None) or 'mirrulations'
+    return [DiskSaver(), S3Saver(bucket_name=bucket)]
 
 
 def is_client_keys_path_configured():
@@ -62,8 +84,7 @@ class Client:
     """
     def __init__(self, redis_server, job_queue, manager):
         self.path_generator = PathGenerator()
-        self.saver = Saver(savers=[DiskSaver(),
-                                   S3Saver(bucket_name="mirrulations")])
+        self.saver = Saver(savers=_build_savers())
         self.redis = redis_server
         self.job_queue = job_queue
         self.cache = JobStatistics(redis_server)
@@ -354,6 +375,8 @@ class Client:
             result = response.json()
 
             self._download_job(job, result)
+        except S3SaveError:
+            raise
         except Exception:
             print(
                 f'FAILURE: bad job job_id={job["job_id"]} url={job["url"]}',
@@ -401,5 +424,12 @@ if __name__ == '__main__':
             print("The Job Queue is down.")
         except AMQPConnectionError:
             print("RabbitMQ is still loading")
+        except S3SaveError as exc:
+            print(
+                'FAILURE: S3 storage error — data may not have reached the '
+                f'bucket. {exc}',
+                flush=True)
+            if exc.__cause__ is not None:
+                print(f'  Cause: {exc.__cause__!r}', flush=True)
 
         time.sleep(key_manager.seconds_between_api_calls())

--- a/mirrulations-client/src/mirrclient/s3_saver.py
+++ b/mirrulations-client/src/mirrclient/s3_saver.py
@@ -5,6 +5,10 @@ import boto3
 from botocore.exceptions import ClientError
 
 
+class S3SaveError(Exception):
+    """Raised when S3 fails (credentials, permissions, or API error)."""
+
+
 class S3Saver():
     """
     A class which handles saving to an S3 bucket
@@ -42,7 +46,6 @@ class S3Saver():
         Returns S3 client connection using aws credentials
         """
         if self.get_credentials() is False:
-            print("No AWS credentials provided, Unable to write to S3.")
             return False
         return boto3.client(
                     's3',
@@ -79,7 +82,9 @@ class S3Saver():
         """
         path = path.replace("/data/", "")
         if self.s3_client is False:
-            return False
+            raise S3SaveError(
+                "No AWS credentials provided; cannot write to S3."
+            ) from None
         try:
             response = self.s3_client.put_object(
                 Bucket=self.bucket_name,
@@ -88,9 +93,10 @@ class S3Saver():
                 )
             print(f"Wrote json to S3: {path}")
             return response
-        except ClientError as e:
-            print(f"Error writing json to S3: {e}")
-            return False
+        except ClientError as exc:
+            raise S3SaveError(
+                f"S3 put_object failed for s3://{self.bucket_name}/{path}"
+            ) from exc
 
     def save_binary(self, path, binary):
         """
@@ -107,7 +113,9 @@ class S3Saver():
         """
         path = path.replace("/data/", "")
         if self.s3_client is False:
-            return False
+            raise S3SaveError(
+                "No AWS credentials provided; cannot write to S3."
+            ) from None
         try:
             response = self.s3_client.put_object(
                 Bucket=self.bucket_name,
@@ -115,9 +123,10 @@ class S3Saver():
                 Body=binary)
             print(f"Wrote binary to S3: {path}")
             return response
-        except ClientError as e:
-            print(f"Error writing json to S3: {e}")
-            return False
+        except ClientError as exc:
+            raise S3SaveError(
+                f"S3 put_object failed for s3://{self.bucket_name}/{path}"
+            ) from exc
 
     def save_text(self, path, text):
         """
@@ -134,7 +143,9 @@ class S3Saver():
         """
         path = path.replace("/data/", "")
         if self.s3_client is False:
-            return False
+            raise S3SaveError(
+                "No AWS credentials provided; cannot write to S3."
+            ) from None
         try:
             response = self.s3_client.put_object(
                 Bucket=self.bucket_name,
@@ -142,6 +153,7 @@ class S3Saver():
                 Body=text)
             print(f"Wrote extracted text to S3: {path}")
             return response
-        except ClientError as e:
-            print(f"Error writing json to S3: {e}")
-            return False
+        except ClientError as exc:
+            raise S3SaveError(
+                f"S3 put_object failed for s3://{self.bucket_name}/{path}"
+            ) from exc

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -7,7 +7,10 @@ import requests_mock
 from requests.exceptions import ReadTimeout
 import boto3
 from mirrcore.path_generator import PathGenerator
-from mirrclient.client import Client, is_client_keys_path_configured
+from mirrclient.client import Client, _build_savers, \
+    is_client_keys_path_configured
+from mirrclient.disk_saver import DiskSaver
+from mirrclient.s3_saver import S3Saver
 from mirrclient.exceptions import NoJobsAvailableException, APITimeoutException
 from mirrclient.key_manager import KeyManager
 from mirrmock.mock_redis import ReadyRedis, InactiveRedis, MockRedisWithStorage
@@ -543,3 +546,32 @@ def test_client_downloads_document_html(capsys, mocker, key_manager):
             '1_content.html\n')
     ]
     assert captured.out == "".join(print_data)
+
+
+def test_build_savers_default_bucket_when_unset(monkeypatch):
+    monkeypatch.delenv('S3_BUCKET', raising=False)
+    savers = _build_savers()
+    assert len(savers) == 2
+    assert isinstance(savers[0], DiskSaver)
+    assert isinstance(savers[1], S3Saver)
+    assert savers[1].bucket_name == 'mirrulations'
+
+
+def test_build_savers_custom_bucket(monkeypatch):
+    monkeypatch.setenv('S3_BUCKET', 'my-custom-bucket')
+    savers = _build_savers()
+    assert len(savers) == 2
+    assert savers[1].bucket_name == 'my-custom-bucket'
+
+
+def test_build_savers_empty_env_disables_s3(monkeypatch):
+    monkeypatch.setenv('S3_BUCKET', '')
+    savers = _build_savers()
+    assert len(savers) == 1
+    assert isinstance(savers[0], DiskSaver)
+
+
+def test_build_savers_whitespace_only_disables_s3(monkeypatch):
+    monkeypatch.setenv('S3_BUCKET', '   ')
+    savers = _build_savers()
+    assert len(savers) == 1

--- a/mirrulations-client/tests/test_s3_saver.py
+++ b/mirrulations-client/tests/test_s3_saver.py
@@ -2,9 +2,9 @@ import os
 from unittest.mock import patch
 import boto3
 from moto import mock_aws
-from pytest import fixture
+import pytest
 from botocore.exceptions import ClientError
-from mirrclient.s3_saver import S3Saver
+from mirrclient.s3_saver import S3Saver, S3SaveError
 
 
 def create_mock_mirrulations_bucket():
@@ -13,7 +13,7 @@ def create_mock_mirrulations_bucket():
     return conn
 
 
-@fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def mock_env():
     os.environ['AWS_ACCESS_KEY'] = 'test_key'
     os.environ['AWS_SECRET_ACCESS_KEY'] = 'test_secret_key'
@@ -34,30 +34,22 @@ def test_get_s3_client_no_env_variables_present():
     assert S3Saver().get_credentials() is False
 
 
-def test_try_saving_json_without_credentials(capsys):
+def test_try_saving_json_without_credentials():
     del os.environ['AWS_ACCESS_KEY']
     del os.environ['AWS_SECRET_ACCESS_KEY']
     s3_saver = S3Saver()
-    s3_saver.save_json("path", "json")
     assert s3_saver.get_credentials() is False
-    captured = capsys.readouterr()
-    print_data = [
-        'No AWS credentials provided, Unable to write to S3.\n',
-    ]
-    assert captured.out == "".join(print_data)
+    with pytest.raises(S3SaveError, match='No AWS credentials'):
+        s3_saver.save_json("path", {"results": {}})
 
 
-def test_try_saving_binary_without_credentials(capsys):
+def test_try_saving_binary_without_credentials():
     del os.environ['AWS_ACCESS_KEY']
     del os.environ['AWS_SECRET_ACCESS_KEY']
     s3_saver = S3Saver()
-    s3_saver.save_binary("path", "json")
     assert s3_saver.get_credentials() is False
-    captured = capsys.readouterr()
-    print_data = [
-        'No AWS credentials provided, Unable to write to S3.\n',
-    ]
-    assert captured.out == "".join(print_data)
+    with pytest.raises(S3SaveError, match='No AWS credentials'):
+        s3_saver.save_binary("path", b"x")
 
 
 @mock_aws
@@ -102,32 +94,29 @@ def test_save_text_to_bucket():
     assert response["ResponseMetadata"]['HTTPStatusCode'] == 200
 
 
-def test_save_json_to_s3_no_credentials_returns_false(capsys):
+def test_save_json_to_s3_no_credentials_raises():
     del os.environ['AWS_ACCESS_KEY']
     del os.environ['AWS_SECRET_ACCESS_KEY']
-    assert S3Saver().save_json("test", "test") is False
-    assert capsys.readouterr().out == "No AWS credentials provided, "\
-                                      "Unable to write to S3.\n"
+    with pytest.raises(S3SaveError, match='No AWS credentials'):
+        S3Saver().save_json("test", {"results": {}})
 
 
-def test_save_binary_to_s3_no_credentials_returns_false(capsys):
+def test_save_binary_to_s3_no_credentials_raises():
     del os.environ['AWS_ACCESS_KEY']
     del os.environ['AWS_SECRET_ACCESS_KEY']
-    assert S3Saver().save_binary("test", "test") is False
-    assert capsys.readouterr().out == "No AWS credentials provided, "\
-                                      "Unable to write to S3.\n"
+    with pytest.raises(S3SaveError, match='No AWS credentials'):
+        S3Saver().save_binary("test", b"x")
 
 
-def test_save_text_to_s3_no_credentials_returns_false(capsys):
+def test_save_text_to_s3_no_credentials_raises():
     del os.environ['AWS_ACCESS_KEY']
     del os.environ['AWS_SECRET_ACCESS_KEY']
-    assert S3Saver().save_text("test", "test") is False
-    assert capsys.readouterr().out == "No AWS credentials provided, "\
-                                      "Unable to write to S3.\n"
+    with pytest.raises(S3SaveError, match='No AWS credentials'):
+        S3Saver().save_text("test", "text")
 
 
 @mock_aws
-def test_save_json_access_denied_returns_false_and_no_write(capsys):
+def test_save_json_access_denied_raises_and_no_write():
     conn = create_mock_mirrulations_bucket()
     s3_saver = S3Saver(bucket_name="test-mirrulations1")
     error = ClientError(
@@ -135,13 +124,13 @@ def test_save_json_access_denied_returns_false_and_no_write(capsys):
         "PutObject"
     )
     with patch.object(s3_saver.s3_client, "put_object", side_effect=error):
-        assert s3_saver.save_json("nope.json", {"results": "bar"}) is False
-    assert "Error writing json to S3:" in capsys.readouterr().out
+        with pytest.raises(S3SaveError, match='put_object failed'):
+            s3_saver.save_json("nope.json", {"results": "bar"})
     assert len(list(conn.Bucket("test-mirrulations1").objects.all())) == 0
 
 
 @mock_aws
-def test_save_binary_access_denied_returns_false_and_no_write(capsys):
+def test_save_binary_access_denied_raises_and_no_write():
     conn = create_mock_mirrulations_bucket()
     s3_saver = S3Saver(bucket_name="test-mirrulations1")
     error = ClientError(
@@ -149,13 +138,13 @@ def test_save_binary_access_denied_returns_false_and_no_write(capsys):
         "PutObject"
     )
     with patch.object(s3_saver.s3_client, "put_object", side_effect=error):
-        assert s3_saver.save_binary("data/forbidden.binary", b"\x17") is False
-    assert "Error writing json to S3:" in capsys.readouterr().out
+        with pytest.raises(S3SaveError, match='put_object failed'):
+            s3_saver.save_binary("data/forbidden.binary", b"\x17")
     assert len(list(conn.Bucket("test-mirrulations1").objects.all())) == 0
 
 
 @mock_aws
-def test_save_text_access_denied_returns_false_and_no_write(capsys):
+def test_save_text_access_denied_raises_and_no_write():
     conn = create_mock_mirrulations_bucket()
     s3_saver = S3Saver(bucket_name="test-mirrulations1")
     error = ClientError(
@@ -163,6 +152,6 @@ def test_save_text_access_denied_returns_false_and_no_write(capsys):
         "PutObject"
     )
     with patch.object(s3_saver.s3_client, "put_object", side_effect=error):
-        assert s3_saver.save_text("data/forbidden.txt", "test") is False
-    assert "Error writing json to S3:" in capsys.readouterr().out
+        with pytest.raises(S3SaveError, match='put_object failed'):
+            s3_saver.save_text("data/forbidden.txt", "test")
     assert len(list(conn.Bucket("test-mirrulations1").objects.all())) == 0


### PR DESCRIPTION
S3_BUCKET is a new entry in client.env.  See docs for details.

This also made S3 errors populate to the client top-level for loggins.