### PR TITLE
Refactor to move iteration of attachments outside PathGenerator.

### DIFF
--- a/mirrulations-client/src/mirrclient/client.py
+++ b/mirrulations-client/src/mirrclient/client.py
@@ -29,6 +29,10 @@ from mirrclient.key_manager import (
 )
 from mirrcore.redis_check import load_redis
 from mirrcore.path_generator import PathGenerator
+from mirrcore.comment_attachments import (
+    comment_attachment_file_format_count,
+    iter_comment_attachment_file_formats,
+)
 from mirrcore.job_queue import JobQueue
 from mirrcore.jobs_statistics import JobStatistics
 from mirrcore.job_queue_exceptions import JobQueueException
@@ -338,27 +342,20 @@ class Client:
         except requests.exceptions.ReadTimeout as exc:
             raise APITimeoutException from exc
 
-    @staticmethod
-    def _included_has_usable_file_formats(included):
-        blocks = included['attributes']['fileFormats']
-        return blocks and blocks not in ('null', None)
-
-    def _iter_comment_attachment_slots(self, comment_json, path_list, key_id):
-        """Yield each attachment slot in lockstep with ``path_list`` ordering."""
+    def _iter_comment_attachment_slots(self, comment_json, key_id):
+        """Yield each attachment URL/path pair during comment downloads."""
         attachment_entity = comment_json['data']['id']
-        idx = 0
-        for included in comment_json['included']:
-            if not self._included_has_usable_file_formats(included):
-                continue
-            for attachment in included['attributes']['fileFormats']:
-                yield _CommentAttachmentSlot(
-                    attachment['fileUrl'],
-                    path_list[idx],
-                    attachment_entity,
-                    key_id,
-                    idx + 1,
-                )
-                idx += 1
+        for idx, file_format in enumerate(
+                iter_comment_attachment_file_formats(comment_json)):
+            attach_path = self.path_generator.get_comment_attachment_path(
+                comment_json, file_format)
+            yield _CommentAttachmentSlot(
+                file_format['fileUrl'],
+                attach_path,
+                attachment_entity,
+                key_id,
+                idx + 1,
+            )
 
     def _persist_comment_attachment_and_record_stats(self, slot):
         """Fetch one attachment file, log it, and bump dashboard counters."""
@@ -386,15 +383,15 @@ class Client:
         key_id : str
             API credential id.
         '''
-        path_list = self.path_generator.get_attachment_json_paths(comment_json)
+        count = comment_attachment_file_format_count(comment_json)
         attachment_entity = comment_json['data']['id']
         logger.debug(
             'Comment attachments scheduled count=%s entity=%s',
-            len(path_list),
+            count,
             attachment_entity,
         )
         for slot in self._iter_comment_attachment_slots(
-                comment_json, path_list, key_id):
+                comment_json, key_id):
             self._persist_comment_attachment_and_record_stats(slot)
 
     def _download_single_attachment(self, url, path):

--- a/mirrulations-client/tests/test_client.py
+++ b/mirrulations-client/tests/test_client.py
@@ -7,6 +7,7 @@ import pytest
 import requests_mock
 from requests.exceptions import ReadTimeout
 import boto3
+from mirrcore.comment_attachments import comment_attachment_file_format_count
 from mirrcore.path_generator import PathGenerator
 from mirrclient.client import Client, _build_savers, \
     is_client_keys_path_configured
@@ -260,7 +261,7 @@ def test_does_comment_have_attachment_does_have_attachment(key_manager):
 
 
 @responses.activate
-def test_handles_none_in_comment_file_formats(path_generator, key_manager):
+def test_handles_none_in_comment_file_formats(key_manager):
     """
     Test for handling of the NoneType Error caused by null fileformats
     """
@@ -288,8 +289,7 @@ def test_handles_none_in_comment_file_formats(path_generator, key_manager):
                   json=test_json, status=200)
     client.job_operation(key_manager.get_next())
 
-    attachment_paths = path_generator.get_attachment_json_paths(test_json)
-    assert attachment_paths == []
+    assert comment_attachment_file_format_count(test_json) == 0
 
 
 @responses.activate

--- a/mirrulations-core/src/mirrcore/comment_attachments.py
+++ b/mirrulations-core/src/mirrcore/comment_attachments.py
@@ -1,0 +1,29 @@
+"""Walk Regulations.gov comment JSON for attachment ``fileFormats`` entries."""
+
+
+def file_formats_usable(blocks):
+    """True when ``fileFormats`` is a non-empty list (not API ``null`` sentinel)."""
+    if blocks in ('null', None) or not blocks:
+        return False
+    return True
+
+
+def iter_comment_attachment_file_formats(comment_json):
+    """
+    Yield each ``file_format`` dict under ``included`` that contains ``fileUrl``.
+
+    Order: each ``included`` element in list order, then each ``fileFormats``
+    entry in list order (only formats with ``fileUrl`` are yielded).
+    """
+    for block in comment_json.get('included', []):
+        formats = block.get('attributes', {}).get('fileFormats')
+        if not file_formats_usable(formats):
+            continue
+        for file_format in formats:
+            if 'fileUrl' in file_format:
+                yield file_format
+
+
+def comment_attachment_file_format_count(comment_json):
+    """Number of attachment file-format slots (same iteration as the iterator)."""
+    return sum(1 for _ in iter_comment_attachment_file_formats(comment_json))

--- a/mirrulations-core/src/mirrcore/path_generator.py
+++ b/mirrulations-core/src/mirrcore/path_generator.py
@@ -96,30 +96,19 @@ class PathGenerator:
         return f'/{agency_i_d}/{docket_i_d}/text-{docket_i_d}/comments/' + \
                f'{item_i_d}.json'
 
-    def _parse_attachment_path(self, json, file_format, attachments):
-        agency_i_d, docket_i_d, item_i_d = self.get_attributes(json)
-        if "fileUrl" in file_format:
-            attachment_name = item_i_d + "_" + \
-                file_format["fileUrl"].split("/")[-1]
-            attachments.append(f'/raw-data/{agency_i_d}/{docket_i_d}/' +
-                               f'binary-{docket_i_d}/comments_' +
-                               f'attachments/{attachment_name}')
-        return attachments
+    def get_comment_attachment_path(self, json_data, file_format):
+        """
+        Storage path for one comment attachment.
 
-    def get_attachment_json_paths(self, json):
-        '''
-        Given a json, this function will return all attachment paths for
-        n number attachment links
-        '''
-
-        # contains list of paths for attachments
-        attachments = []
-        for attachment in json["included"]:
-            attributes = attachment["attributes"]
-            if attributes.get("fileFormats"):
-                for file_format in attributes["fileFormats"]:
-                    attachments = self._parse_attachment_path(json,
-                                                              file_format,
-                                                              attachments)
-
-        return attachments
+        ``file_format`` must be a ``fileFormats`` element that includes
+        ``fileUrl`` (typically taken from ``iter_comment_attachment_file_formats``
+        in ``mirrcore.comment_attachments``).
+        """
+        if 'fileUrl' not in file_format:
+            raise ValueError('file_format must contain fileUrl')
+        agency_i_d, docket_i_d, item_i_d = self.get_attributes(json_data)
+        tail = file_format['fileUrl'].split('/')[-1]
+        return (
+            f'/raw-data/{agency_i_d}/{docket_i_d}/binary-{docket_i_d}/comments_'
+            f'attachments/{item_i_d}_{tail}'
+        )

--- a/mirrulations-core/tests/test_comment_attachments.py
+++ b/mirrulations-core/tests/test_comment_attachments.py
@@ -1,0 +1,82 @@
+from mirrcore.comment_attachments import (
+    comment_attachment_file_format_count,
+    file_formats_usable,
+    iter_comment_attachment_file_formats,
+)
+
+
+def test_file_formats_usable():
+    assert file_formats_usable([{}]) is True
+    assert file_formats_usable(None) is False
+    assert file_formats_usable('null') is False
+
+
+def test_iter_and_count_single_attachment():
+    link = (
+        'https://downloads.regulations.gov/FDA-2017-D-2335-1566/attachment_1.pdf'
+    )
+    comment_json = {
+        'data': {
+            'id': 'FDA-2017-D-2335-1566',
+            'type': 'comments',
+            'attributes': {
+                'agencyId': 'FDA',
+                'docketId': 'FDA-2017-D-2335',
+            },
+        },
+        'included': [{
+            'attributes': {
+                'fileFormats': [{'fileUrl': link}],
+            },
+        }],
+    }
+    formats = list(iter_comment_attachment_file_formats(comment_json))
+    assert len(formats) == 1
+    assert formats[0]['fileUrl'] == link
+    assert comment_attachment_file_format_count(comment_json) == 1
+
+
+def test_iter_skips_null_file_formats_and_formats_without_url():
+    comment_json = {
+        'data': {
+            'id': 'FDA-2017-D-2335-1566',
+            'type': 'comments',
+            'attributes': {
+                'agencyId': 'FDA',
+                'docketId': 'FDA-2017-D-2335',
+            },
+        },
+        'included': [{
+            'attributes': {
+                'fileFormats': None,
+            },
+        }],
+    }
+    assert not list(iter_comment_attachment_file_formats(comment_json))
+    assert comment_attachment_file_format_count(comment_json) == 0
+
+
+def test_two_file_formats_one_included_yields_two():
+    comment_json = {
+        'data': {
+            'id': 'agencyID-001-0002',
+            'type': 'comments',
+            'attributes': {
+                'agencyId': 'agencyID',
+                'docketId': 'agencyID-001',
+            },
+        },
+        'included': [{
+            'attributes': {
+                'fileFormats': [
+                    {'fileUrl': 'https://downloads.regulations.gov/.pdf'},
+                    {'fileUrl': 'https://downloads.regulations.gov/.doc'},
+                ],
+            },
+        }],
+    }
+    assert comment_attachment_file_format_count(comment_json) == 2
+    urls = [f['fileUrl'] for f in iter_comment_attachment_file_formats(
+        comment_json)]
+    assert urls[0].endswith('.pdf')
+    assert urls[1].endswith('.doc')

--- a/mirrulations-core/tests/test_path_generator.py
+++ b/mirrulations-core/tests/test_path_generator.py
@@ -1,3 +1,9 @@
+import pytest
+
+from mirrcore.comment_attachments import (
+    comment_attachment_file_format_count,
+    iter_comment_attachment_file_formats,
+)
 from mirrcore.path_generator import PathGenerator
 from pytest import fixture
 
@@ -414,13 +420,17 @@ def test_get_comment_path_with_missing_agency_i_d_key(generator):
 # Comments Attachments
 def test_attachment_comment_paths(generator):
     json_pls = get_attachment_and_comment()
-    expected_path = ["/raw-data/FDA/FDA-2017-D-2335/binary-FDA-2017-D-2335" +
-                     "/comments_attachments/" +
-                     "FDA-2017-D-2335-1566_attachment_1.pdf"]
-    assert expected_path == generator.get_attachment_json_paths(json_pls)
+    expected = (
+        "/raw-data/FDA/FDA-2017-D-2335/binary-FDA-2017-D-2335/"
+        "comments_attachments/FDA-2017-D-2335-1566_attachment_1.pdf"
+    )
+    assert comment_attachment_file_format_count(json_pls) == 1
+    first_fmt = next(iter_comment_attachment_file_formats(json_pls))
+    assert generator.get_comment_attachment_path(json_pls, first_fmt) == (
+        expected)
 
 
-def test_null_file_format_for_attachment_comment_returns_nothing(generator):
+def test_null_file_format_for_attachment_comment_returns_nothing():
     comment_json = {
         "data": {
             "id": "FDA-2017-D-2335-1566",
@@ -435,4 +445,11 @@ def test_null_file_format_for_attachment_comment_returns_nothing(generator):
                 "fileFormats": None  # A file format with No attachments
             }
         }]}
-    assert generator.get_attachment_json_paths(comment_json) == []
+    assert comment_attachment_file_format_count(comment_json) == 0
+    assert not list(iter_comment_attachment_file_formats(comment_json))
+
+
+def test_get_comment_attachment_path_requires_file_url():
+    generator = PathGenerator()
+    with pytest.raises(ValueError):
+        generator.get_comment_attachment_path(get_attachment_and_comment(), {})


### PR DESCRIPTION
This is in prepearation for a refactor of the client.  It will support using the new iterator in comment_attachments to do

for attachment in docket # from generator
  download attachment
  if success
    generate save path
    save attachment
  else
    generate tombstone #forthcoming logic
    save tombstone #forthcoming logic